### PR TITLE
feat: breadcrumbs

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,16 @@
+<<<<<<< Updated upstream
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
+=======
+import { Link, Links, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
+>>>>>>> Stashed changes
 import '~/styles/index.scss';
 import { SiteWrapper } from '~/components/site-wrapper/site-wrapper';
+import { ROUTES } from '~/router/config';
+import { RouteHandle } from '@remix-run/react/dist/routeModules';
+
+export const handle: RouteHandle = {
+    breadcrumb: () => <Link to={ROUTES.home.path}>Home</Link>,
+};
 
 export default function App() {
     return (

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream
-import { Links, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
-=======
-import { Link, Links, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
->>>>>>> Stashed changes
+import { Links, Link, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
 import '~/styles/index.scss';
 import { SiteWrapper } from '~/components/site-wrapper/site-wrapper';
 import { ROUTES } from '~/router/config';

--- a/app/routes/product-details.$productSlug/product-details.module.scss
+++ b/app/routes/product-details.$productSlug/product-details.module.scss
@@ -1,8 +1,12 @@
 .page {
+    padding-bottom: 3%;
+}
+
+.content {
     display: grid;
     grid-template-columns: 2fr 1fr;
     gap: 32px;
-    padding: 3% 0;
+    margin-top: 36px;
 }
 
 .productName {

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -1,7 +1,7 @@
 import { getEcomApi } from '~/api/ecom-api';
 import styles from './product-details.module.scss';
 import { json, LoaderFunctionArgs } from '@remix-run/node';
-import { Link, useLoaderData } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 import { ProductPrice } from '~/components/product-price/product-price';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { useState } from 'react';
@@ -11,9 +11,9 @@ import { Button } from '~/components/button/button';
 import { removeQueryStringFromUrl } from '~/utils';
 import { ShareProductLinks } from '~/components/share-product-links/share-product-links';
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
-import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
 import { CategoryLink } from '~/components/category-link/category-link';
+import { ProductLink } from '~/components/product-link/product-link';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     const productSlug = params.productSlug;
@@ -43,9 +43,9 @@ export const handle: RouteHandle<typeof loader, ProductDetailsLocationState> = {
         const fromCategory = location.state?.fromCategory;
 
         const productLink = (
-            <Link to={ROUTES.productDetails.to(match.data.product.slug!)} state={{ fromCategory }}>
+            <ProductLink productSlug={match.data.product.slug!} state={{ fromCategory }}>
                 {match.data.product.name!}
-            </Link>
+            </ProductLink>
         );
 
         if (fromCategory) {

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -1,7 +1,7 @@
 import { getEcomApi } from '~/api/ecom-api';
 import styles from './product-details.module.scss';
 import { json, LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { Link, useLoaderData } from '@remix-run/react';
 import { ProductPrice } from '~/components/product-price/product-price';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { useState } from 'react';
@@ -10,6 +10,9 @@ import { ProductImages } from '~/components/product-images/product-images';
 import { Button } from '~/components/button/button';
 import { removeQueryStringFromUrl } from '~/utils';
 import { ShareProductLinks } from '~/components/share-product-links/share-product-links';
+import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
+import { ROUTES } from '~/router/config';
+import { RouteHandle } from '~/router/types';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     const productSlug = params.productSlug;
@@ -27,54 +30,91 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     return json({ product, canonicalUrl });
 };
 
+interface ProductDetailsLocationState {
+    fromCategory?: {
+        name: string;
+        slug: string;
+    };
+}
+
+export const handle: RouteHandle<typeof loader, ProductDetailsLocationState> = {
+    breadcrumb: (match, location) => {
+        const fromCategory = location.state?.fromCategory;
+
+        const productLink = (
+            <Link to={ROUTES.productDetails.to(match.data.product.slug!)} state={{ fromCategory }}>
+                {match.data.product.name!}
+            </Link>
+        );
+
+        if (fromCategory) {
+            const categoryLink = (
+                <Link to={ROUTES.products.to(fromCategory.slug)}>{fromCategory.name}</Link>
+            );
+            return [categoryLink, productLink];
+        }
+
+        return productLink;
+    },
+};
+
 export default function ProductDetailsPage() {
     const { product, canonicalUrl } = useLoaderData<typeof loader>();
     const [quantity, setQuantity] = useState(1);
 
     return (
         <div className={styles.page}>
-            <ProductImages media={product.media} />
+            <Breadcrumbs />
 
-            <div>
-                <h1 className={styles.productName}>{product.name}</h1>
-                {product.sku && <p className={styles.sku}>SKU: {product.sku}</p>}
+            <div className={styles.content}>
+                <ProductImages media={product.media} />
 
-                {product.priceData && (
-                    <ProductPrice priceData={product.priceData} className={styles.price} />
-                )}
+                <div>
+                    <h1 className={styles.productName}>{product.name}</h1>
+                    {product.sku && <p className={styles.sku}>SKU: {product.sku}</p>}
 
-                {product.description && (
-                    <div
-                        className={styles.description}
-                        dangerouslySetInnerHTML={{ __html: product.description }}
+                    {product.priceData && (
+                        <ProductPrice priceData={product.priceData} className={styles.price} />
+                    )}
+
+                    {product.description && (
+                        <div
+                            className={styles.description}
+                            dangerouslySetInnerHTML={{ __html: product.description }}
+                        />
+                    )}
+
+                    <div className={styles.quantity}>
+                        <label htmlFor="quantity" className={styles.quantityLabel}>
+                            Quantity
+                        </label>
+                        <QuantityInput id="quantity" value={quantity} onChange={setQuantity} />
+                    </div>
+
+                    <Button className={styles.addToCartButton}>Add to Cart</Button>
+
+                    {product.additionalInfoSections &&
+                        product.additionalInfoSections.length > 0 && (
+                            <Accordion
+                                className={styles.additionalInfoSections}
+                                items={product.additionalInfoSections.map((section) => ({
+                                    title: section.title!,
+                                    content: section.description ? (
+                                        <div
+                                            dangerouslySetInnerHTML={{
+                                                __html: section.description,
+                                            }}
+                                        />
+                                    ) : null,
+                                }))}
+                            />
+                        )}
+
+                    <ShareProductLinks
+                        className={styles.socialLinks}
+                        productCanonicalUrl={canonicalUrl}
                     />
-                )}
-
-                <div className={styles.quantity}>
-                    <label htmlFor="quantity" className={styles.quantityLabel}>
-                        Quantity
-                    </label>
-                    <QuantityInput id="quantity" value={quantity} onChange={setQuantity} />
                 </div>
-
-                <Button className={styles.addToCartButton}>Add to Cart</Button>
-
-                {product.additionalInfoSections && product.additionalInfoSections.length > 0 && (
-                    <Accordion
-                        className={styles.additionalInfoSections}
-                        items={product.additionalInfoSections.map((section) => ({
-                            title: section.title!,
-                            content: section.description ? (
-                                <div dangerouslySetInnerHTML={{ __html: section.description }} />
-                            ) : null,
-                        }))}
-                    />
-                )}
-
-                <ShareProductLinks
-                    className={styles.socialLinks}
-                    productCanonicalUrl={canonicalUrl}
-                />
             </div>
         </div>
     );

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -13,6 +13,7 @@ import { ShareProductLinks } from '~/components/share-product-links/share-produc
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
+import { CategoryLink } from '~/components/category-link/category-link';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     const productSlug = params.productSlug;
@@ -49,7 +50,7 @@ export const handle: RouteHandle<typeof loader, ProductDetailsLocationState> = {
 
         if (fromCategory) {
             const categoryLink = (
-                <Link to={ROUTES.products.to(fromCategory.slug)}>{fromCategory.name}</Link>
+                <CategoryLink categorySlug={fromCategory.slug}>{fromCategory.name}</CategoryLink>
             );
             return [categoryLink, productLink];
         }

--- a/app/routes/products.$categorySlug/products.module.scss
+++ b/app/routes/products.$categorySlug/products.module.scss
@@ -1,7 +1,11 @@
 .page {
-    padding: 20px 0 3%;
+    padding-bottom: 3%;
+}
+
+.content {
     display: flex;
     gap: 40px;
+    margin-top: 36px;
 }
 
 .navigation {

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -50,29 +50,7 @@ export default function ProductsPage() {
 
     return (
         <div className={styles.page}>
-<<<<<<< Updated upstream
-            <nav className={styles.navigation}>
-                <h2 className={styles.navigationTitle}>Browse by</h2>
-                <ul>
-                    {allCategories.map((category) => (
-                        <li key={category._id} className={styles.categoryListItem}>
-                            <CategoryLink
-                                categorySlug={category.slug!}
-                                className={({ isActive }) =>
-                                    classNames(styles.categoryLink, {
-                                        [styles.categoryLinkActive]: isActive,
-                                    })
-                                }
-                            >
-                                {category.name}
-                            </CategoryLink>
-                        </li>
-                    ))}
-                </ul>
-            </nav>
-=======
             <Breadcrumbs />
->>>>>>> Stashed changes
 
             <div className={styles.content}>
                 <nav className={styles.navigation}>
@@ -81,7 +59,6 @@ export default function ProductsPage() {
                         {allCategories.map((category) => (
                             <li key={category._id} className={styles.categoryListItem}>
                                 <CategoryLink
-                                    title={category.name}
                                     categorySlug={category.slug!}
                                     className={({ isActive }) =>
                                         classNames(styles.categoryLink, {

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -41,7 +41,9 @@ export const loader = async ({ params: { categorySlug } }: LoaderFunctionArgs) =
 
 export const handle: RouteHandle<typeof loader> = {
     breadcrumb: (match) => (
-        <Link to={ROUTES.products.to(match.data.category.slug!)}>{match.data.category.name!}</Link>
+        <CategoryLink categorySlug={match.data.category.slug!}>
+            {match.data.category.name!}
+        </CategoryLink>
     ),
 };
 
@@ -65,7 +67,9 @@ export default function ProductsPage() {
                                             [styles.categoryLinkActive]: isActive,
                                         })
                                     }
-                                />
+                                >
+                                    {category.name}
+                                </CategoryLink>
                             </li>
                         ))}
                     </ul>

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -1,5 +1,5 @@
 import { type LoaderFunctionArgs, redirect, json } from '@remix-run/node';
-import { Link, useLoaderData } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 import { getEcomApi } from '~/api/ecom-api';
 import { ROUTES } from '~/router/config';
 import styles from './products.module.scss';
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import { CategoryLink } from '~/components/category-link/category-link';
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
 import { RouteHandle } from '~/router/types';
+import { ProductLink } from '~/components/product-link/product-link';
 
 export const loader = async ({ params: { categorySlug } }: LoaderFunctionArgs) => {
     const api = getEcomApi();
@@ -88,9 +89,9 @@ export default function ProductsPage() {
 
                     <div className={styles.productsList}>
                         {categoryProducts.map((product) => (
-                            <Link
+                            <ProductLink
                                 key={product._id}
-                                to={ROUTES.productDetails.to(product.slug!)}
+                                productSlug={product.slug!}
                                 state={{
                                     fromCategory: {
                                         name: category.name,
@@ -104,7 +105,7 @@ export default function ProductsPage() {
                                     priceData={product.priceData}
                                     ribbon={product.ribbon ?? undefined}
                                 />
-                            </Link>
+                            </ProductLink>
                         ))}
                     </div>
                 </div>

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -7,6 +7,8 @@ import { ProductCard } from '~/components/product-card/product-card';
 import { collections } from '@wix/stores';
 import classNames from 'classnames';
 import { CategoryLink } from '~/components/category-link/category-link';
+import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
+import { RouteHandle } from '~/router/types';
 
 export const loader = async ({ params: { categorySlug } }: LoaderFunctionArgs) => {
     const api = getEcomApi();
@@ -37,11 +39,18 @@ export const loader = async ({ params: { categorySlug } }: LoaderFunctionArgs) =
     return json({ category, categoryProducts, allCategories });
 };
 
+export const handle: RouteHandle<typeof loader> = {
+    breadcrumb: (match) => (
+        <Link to={ROUTES.products.to(match.data.category.slug!)}>{match.data.category.name!}</Link>
+    ),
+};
+
 export default function ProductsPage() {
     const { category, categoryProducts, allCategories } = useLoaderData<typeof loader>();
 
     return (
         <div className={styles.page}>
+<<<<<<< Updated upstream
             <nav className={styles.navigation}>
                 <h2 className={styles.navigationTitle}>Browse by</h2>
                 <ul>
@@ -61,29 +70,62 @@ export default function ProductsPage() {
                     ))}
                 </ul>
             </nav>
+=======
+            <Breadcrumbs />
+>>>>>>> Stashed changes
 
-            <div>
-                <h1 className={styles.categoryName}>{category.name}</h1>
-                {category.description && (
-                    <p className={styles.categoryDescription}>{category.description}</p>
-                )}
+            <div className={styles.content}>
+                <nav className={styles.navigation}>
+                    <h2 className={styles.navigationTitle}>Browse by</h2>
+                    <ul>
+                        {allCategories.map((category) => (
+                            <li key={category._id} className={styles.categoryListItem}>
+                                <CategoryLink
+                                    title={category.name}
+                                    categorySlug={category.slug!}
+                                    className={({ isActive }) =>
+                                        classNames(styles.categoryLink, {
+                                            [styles.categoryLinkActive]: isActive,
+                                        })
+                                    }
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                </nav>
 
-                <p className={styles.productsCount}>
-                    {category.numberOfProducts}{' '}
-                    {category.numberOfProducts === 1 ? 'product' : 'products'}
-                </p>
+                <div>
+                    <h1 className={styles.categoryName}>{category.name}</h1>
+                    {category.description && (
+                        <p className={styles.categoryDescription}>{category.description}</p>
+                    )}
 
-                <div className={styles.productsList}>
-                    {categoryProducts.map((product) => (
-                        <Link key={product._id} to={ROUTES.productDetails.to(product.slug!)}>
-                            <ProductCard
-                                name={product.name!}
-                                imageUrl={product.media?.mainMedia?.image?.url}
-                                priceData={product.priceData}
-                                ribbon={product.ribbon ?? undefined}
-                            />
-                        </Link>
-                    ))}
+                    <p className={styles.productsCount}>
+                        {category.numberOfProducts}{' '}
+                        {category.numberOfProducts === 1 ? 'product' : 'products'}
+                    </p>
+
+                    <div className={styles.productsList}>
+                        {categoryProducts.map((product) => (
+                            <Link
+                                key={product._id}
+                                to={ROUTES.productDetails.to(product.slug!)}
+                                state={{
+                                    fromCategory: {
+                                        name: category.name,
+                                        slug: category.slug,
+                                    },
+                                }}
+                            >
+                                <ProductCard
+                                    name={product.name!}
+                                    imageUrl={product.media?.mainMedia?.image?.url}
+                                    priceData={product.priceData}
+                                    ribbon={product.ribbon ?? undefined}
+                                />
+                            </Link>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/breadcrumbs/breadcrumbs.module.scss
+++ b/src/components/breadcrumbs/breadcrumbs.module.scss
@@ -1,0 +1,12 @@
+.breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.separatorIcon {
+    width: 21px;
+    height: 21px;
+}

--- a/src/components/breadcrumbs/breadcrumbs.module.scss
+++ b/src/components/breadcrumbs/breadcrumbs.module.scss
@@ -2,8 +2,7 @@
     display: flex;
     align-items: center;
     gap: 4px;
-    font-size: 14px;
-    line-height: 1.6;
+    font: var(--paragraph3);
 }
 
 .separatorIcon {

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useLocation, useMatches } from '@remix-run/react';
 import { RouteMatch } from '~/router/types';
 import styles from './breadcrumbs.module.scss';
@@ -11,10 +12,14 @@ export const Breadcrumbs = () => {
         <div className={styles.breadcrumbs}>
             {matches
                 .flatMap((match) => match.handle?.breadcrumb?.(match, location) ?? [])
-                .map((breadcrumb, index, arr) => [
-                    breadcrumb,
-                    index !== arr.length - 1 && <ArrowRightIcon className={styles.separatorIcon} />,
-                ])}
+                .map((breadcrumb, index, arr) => (
+                    <React.Fragment key={index}>
+                        {breadcrumb}
+                        {index !== arr.length - 1 && (
+                            <ArrowRightIcon className={styles.separatorIcon} />
+                        )}
+                    </React.Fragment>
+                ))}
         </div>
     );
 };

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,20 @@
+import { useLocation, useMatches } from '@remix-run/react';
+import { RouteMatch } from '~/router/types';
+import styles from './breadcrumbs.module.scss';
+import { ArrowRightIcon } from '../icons';
+
+export const Breadcrumbs = () => {
+    const matches = useMatches() as RouteMatch[];
+    const location = useLocation();
+
+    return (
+        <div className={styles.breadcrumbs}>
+            {matches
+                .flatMap((match) => match.handle?.breadcrumb?.(match, location) ?? [])
+                .map((breadcrumb, index, arr) => [
+                    breadcrumb,
+                    index !== arr.length - 1 && <ArrowRightIcon className={styles.separatorIcon} />,
+                ])}
+        </div>
+    );
+};

--- a/src/components/icons/arrow-right.tsx
+++ b/src/components/icons/arrow-right.tsx
@@ -1,0 +1,12 @@
+export const ArrowRightIcon = ({ className }: { className?: string }) => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className={className}
+        >
+            <path d="m8.707 4.998 6.361 6.367.004-.003.707.707-.003.003.002.004-.707.707-.002-.003-6.362 6.363L8 18.436l6.361-6.364L8 5.705l.707-.707Z" />
+        </svg>
+    );
+};

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,3 +1,4 @@
+export { ArrowRightIcon } from './arrow-right';
 export { FacebookIcon } from './facebook';
 export { ImagePlaceholderIcon } from './image-placeholder-icon';
 export { MinusIcon } from './minus-icon';

--- a/src/components/product-link/product-link.tsx
+++ b/src/components/product-link/product-link.tsx
@@ -1,0 +1,14 @@
+import { NavLink, NavLinkProps } from '@remix-run/react';
+import { ROUTES } from '~/router/config';
+
+export interface ProductLinkProps extends Omit<NavLinkProps, 'to'> {
+    productSlug: string;
+}
+
+export const ProductLink = ({ productSlug, children, ...rest }: ProductLinkProps) => {
+    return (
+        <NavLink to={ROUTES.productDetails.to(productSlug)} {...rest}>
+            {children}
+        </NavLink>
+    );
+};

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -1,0 +1,12 @@
+import type { UIMatch, Location } from '@remix-run/react';
+
+export type RouteHandle<Data = unknown, LocationState = unknown> =
+    | {
+          breadcrumb?: (
+              match: RouteMatch<Data>,
+              location: Location<LocationState>
+          ) => React.ReactNode;
+      }
+    | undefined;
+
+export type RouteMatch<Data = unknown> = UIMatch<Data, RouteHandle<Data>>;


### PR DESCRIPTION

<img width="1728" alt="Screenshot 2024-09-17 at 10 41 21" src="https://github.com/user-attachments/assets/e65f64af-6d5a-489f-89c7-f85ba3860b53">
<img width="1728" alt="Screenshot 2024-09-17 at 10 41 27" src="https://github.com/user-attachments/assets/9c22f207-3873-4fcc-8f29-57d809ae869b">


Guide: https://remix.run/docs/en/main/guides/breadcrumbs.

- We don't show breadcrums on every page, only products category and product details.
- On product details we have a special case. Product details route is not nested inside category route. But we want to  show the category link in breadcrumbs if a user visits the product page directly from the category page. I do this using history state. So the category link appears only on the client side.

