### PR TITLE
feat: run full app in codux

### DIFF
--- a/_codux/app.app-def.tsx
+++ b/_codux/app.app-def.tsx
@@ -1,0 +1,6 @@
+import defineRemixApp from '@wixc3/define-remix-app';
+
+export default defineRemixApp({
+    appPath: '../app',
+    routingPattern: 'folder(route)',
+});

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,7 +7,6 @@ import {
     ScrollRestoration,
     useLoaderData,
 } from '@remix-run/react';
-import { json } from '@remix-run/node';
 import { SiteWrapper } from '~/components/site-wrapper/site-wrapper';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
@@ -16,11 +15,11 @@ import { CartOpenContextProvider } from '~/components/cart/cart-open-context';
 import '~/styles/index.scss';
 
 export async function loader() {
-    return json({
+    return {
         ENV: {
             WIX_CLIENT_ID: process?.env?.WIX_CLIENT_ID,
         },
-    });
+    };
 }
 
 export const handle: RouteHandle = {

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -1,6 +1,6 @@
 import { getEcomApi } from '~/api/ecom-api';
 import styles from './product-details.module.scss';
-import { json, LoaderFunctionArgs } from '@remix-run/node';
+import type { LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { ProductPrice } from '~/components/product-price/product-price';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
@@ -30,7 +30,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 
     const canonicalUrl = removeQueryStringFromUrl(request.url);
 
-    return json({ product, canonicalUrl });
+    return { product, canonicalUrl };
 };
 
 interface ProductDetailsLocationState {

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -1,5 +1,5 @@
-import { type LoaderFunctionArgs, redirect, json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunctionArgs } from '@remix-run/node';
+import { useLoaderData, redirect } from '@remix-run/react';
 import { getEcomApi } from '~/api/ecom-api';
 import { ROUTES } from '~/router/config';
 import styles from './products.module.scss';
@@ -37,7 +37,7 @@ export const loader = async ({ params: { categorySlug } }: LoaderFunctionArgs) =
     const categoryProducts = await api.getProductsByCategory(categorySlug);
     const allCategories = await api.getAllCategories();
 
-    return json({ category, categoryProducts, allCategories });
+    return { category, categoryProducts, allCategories };
 };
 
 export const handle: RouteHandle<typeof loader> = {

--- a/codux.config.json
+++ b/codux.config.json
@@ -35,5 +35,9 @@
       "~/*": "./src/*"
     }
   },
-  "svgLoader": "both"
+  "svgLoader": "both",
+  "previewConfiguration": {
+    "environmentVariables": {},
+    "envFile": ".env"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
+        "@wixc3/define-remix-app": "^4.2.0",
         "@wixc3/react-board": "^4.0.0",
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^9.0.0",
@@ -1142,6 +1143,13 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@file-services/types": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@file-services/types/-/types-9.4.1.tgz",
+      "integrity": "sha512-poik5y4EU73vkSjNR86bG5yrPtMyN7CJXYS5TzoeBRbhA6Z3+7+JHBOsdDGDg4wSAi48YFdGXHjFxASI7olDDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1702,6 +1710,31 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/testing": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/testing/-/testing-2.12.0.tgz",
+      "integrity": "sha512-BVa2tw8H0K8tKJJY6wSAj518laQNw7gaHlr7WwHrAOrozi38Dp+GNTcH2PVCg5YJKJqIVf5eSVjHodK3G4qF0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/node": "2.12.0",
+        "@remix-run/react": "2.12.0",
+        "@remix-run/router": "1.19.2",
+        "react-router-dom": "6.26.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3250,12 +3283,45 @@
         "@wix/sdk-types": "^1.9.2"
       }
     },
+    "node_modules/@wixc3/app-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@wixc3/app-core/-/app-core-4.2.0.tgz",
+      "integrity": "sha512-AbmshZ7FeNlCSxssQ+GcoUFzZ+WyqfxMZ/s7Jscn6YAoI0hOLNnsu0iErPepCFOh6tWEsZC8u9h3FTC2W4CbVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@file-services/types": "^9.4.1",
+        "@wixc3/react-board": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/@wixc3/board-core": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@wixc3/board-core/-/board-core-4.0.0.tgz",
       "integrity": "sha512-9kC6+LZdFJcAh9uzAettUqVuu4NRfjQPI2wxvQmA9stMtRY9CiXTSEJLvtP/VcXNQOmyUQVRHURxYSEItUzaWw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@wixc3/define-remix-app": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@wixc3/define-remix-app/-/define-remix-app-4.2.0.tgz",
+      "integrity": "sha512-/WYgwld6+ueC3jZBouCswQZOhvLAXvRVTRDAtHrMWOjmtRWOqoC8rdFePTHTVrMj8S/f4mzeaTZR3n5IEGL7tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/node": "^2.12.0",
+        "@remix-run/react": "^2.12.0",
+        "@remix-run/router": "^1.19.2",
+        "@remix-run/testing": "^2.12.0",
+        "@wixc3/app-core": "^4.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@wixc3/react-board": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@wixc3/react-board": "^4.0.0",
+    "@wixc3/define-remix-app": "^4.2.0",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",


### PR DESCRIPTION
Adds define app config that allows to run a template in full app mode in Codux.

https://github.com/user-attachments/assets/b9ae3843-277a-460b-9f45-b46479a22e67

## **Important note:**
`define-remix-app` wrapper runs all loaders in web workers, it means we can't use node specific login there (e.g. we can't use things from '@remix-run/node' package).

____

## **Known issue:**
`define-remix-app` doesn't pass correctly an error from loader to a route component, that can lead to weird errors

https://github.com/user-attachments/assets/5e61a4d4-5812-4e2a-b527-1c3fa1c5f557

This error appears because `useLoaderData` returns an empty object instead of an error that a category doesn't exist 

## How to run:
At the moment, we need to use `peter/production-app` branch in Codux and run it with a command:
```bash
npm run codux:electron:release
```

