### PR TITLE
fix: disable scroll only when drawer is open

### DIFF
--- a/src/components/drawer/drawer.tsx
+++ b/src/components/drawer/drawer.tsx
@@ -23,7 +23,7 @@ export const Drawer = ({ open, onClose, children }: DrawerProps) => {
     return (
         <div className={classNames(styles.root, { [styles.open]: open })} onClick={onClose}>
             {/* RemoveScroll disables scroll outside the drawer. */}
-            <RemoveScroll>
+            <RemoveScroll enabled={open}>
                 <div className={styles.drawer} onClick={(event) => event.stopPropagation()}>
                     {children}
                 </div>


### PR DESCRIPTION
I made a mistake and completely disabled scroll on all pages. The scroll should be disabled only when the drawer is open.