### PR TITLE
fix: set common class with alternative background

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -59,7 +59,7 @@ export default function HomePage() {
             </div>
 
             <FeaturedProductsSection
-                className={styles.featuredProducts}
+                className="alternateBackground"
                 categorySlug="new-in"
                 title="New In"
                 description="Embrace a sustainable lifestyle with our newest drop-ins."


### PR DESCRIPTION
I removed `featuredProducts` class from the page scss and created `alternateBackground` class in _common.scss_ and forgot to set proper `className` to component.