### PR TITLE
fix: remove horizontal scroll from the home page

### DIFF
--- a/app/routes/_index/index.module.scss
+++ b/app/routes/_index/index.module.scss
@@ -40,8 +40,9 @@
 }
 
 .floatingCardBackground {
-    width: 100vw;
-    margin-left: -2%;
+    /* negate padding from <main> element */
+    margin-inline: -2vw;
+
     padding: 7.8% 11.7%;
     aspect-ratio: 2;
 }


### PR DESCRIPTION
Incorrect styling of the parallax block on the home page was causing horizontal scroll.