### PR TITLE
refactor: prevent duplicate imports of common.scss

### DIFF
--- a/_codux/ui-kit/buttons/ui-kit-buttons.board.module.scss
+++ b/_codux/ui-kit/buttons/ui-kit-buttons.board.module.scss
@@ -1,5 +1,3 @@
-@import '@styles/typography.scss';
-
 .container {
     width: 284px;
     padding: 16px;

--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -1,11 +1,10 @@
-import '~/styles/common.scss';
 import { createBoard, Variant } from '@wixc3/react-board';
-import styles from './components.board.module.scss';
 import classNames from 'classnames';
-import styles0 from './components.board.module.scss';
-import { QuantityInput } from '../../../src/components/quantity-input/quantity-input';
-import { Accordion } from '../../../src/components/accordion/accordion';
-import { ProductCard } from '../../../src/components/product-card/product-card';
+import { Accordion } from '~/components/accordion/accordion';
+import { ProductCard } from '~/components/product-card/product-card';
+import { QuantityInput } from '~/components/quantity-input/quantity-input';
+
+import styles from './components.board.module.scss';
 
 export default createBoard({
     name: 'Components',
@@ -13,13 +12,13 @@ export default createBoard({
         <div className={styles.container}>
             <div>
                 <span className={styles.uikit}>UI Kit</span>
-                <span className={styles.foundation}> | Core components</span>
+                <span className={styles.foundation}> | Core components</span>
                 <hr className={styles.hrSolid} />
                 <h3 className={styles.sectionTitle}>Components &amp; Elements</h3>
                 <h4 className={styles.sectionHeader}>INPUT</h4>
             </div>
-            <QuantityInput value={6} className={styles0.quantityInput1} />
-            <span className={styles0.fontDetails}>Number Input</span>
+            <QuantityInput value={6} className={styles.quantityInput1} onChange={() => {}} />
+            <span className={styles.fontDetails}>Number Input</span>
             <Variant name="Heading1">
                 <hr className={styles.hrLight} />
                 <h4 className={styles.sectionHeader}>ACCORDION</h4>
@@ -27,21 +26,24 @@ export default createBoard({
                     items={[
                         {
                             title: 'Product Info',
+                            content: 'Content',
                         },
                         {
                             title: 'Return & Refund Policy',
+                            content: 'Content',
                         },
                         {
                             title: 'Shipping Info ',
+                            content: 'Content',
                         },
                     ]}
-                    className={styles0.accordion}
+                    className={styles.accordion}
                 />
                 <hr className={styles.hrLight} />
             </Variant>
             <p className={classNames(styles.variantName, styles.headlinesSpacing)}></p>
             <h4 className={styles.sectionHeader}>LABELS</h4>
-            <h4>//Labels missing</h4>
+            <h4>Labels missing</h4>
             <hr className={styles.hrLight} />
             <h4 className={styles.sectionHeader}>CARDS</h4>
             <ProductCard
@@ -53,9 +55,9 @@ export default createBoard({
                     price: 5.5,
                 }}
             />
-            <span className={styles0.fontDetails}>Product Card</span>
-            <h4>//Product gallery missing</h4>
-            <span className={styles0.fontDetails}>Product Card</span>
+            <span className={styles.fontDetails}>Product Card</span>
+            <h4>Product gallery missing</h4>
+            <span className={styles.fontDetails}>Product Card</span>
         </div>
     ),
     environmentProps: {

--- a/_codux/ui-kit/typography/typography.board.module.scss
+++ b/_codux/ui-kit/typography/typography.board.module.scss
@@ -1,7 +1,4 @@
-//@import '@styles/typography.scss';
-
-.root {
-}
+.root {}
 
 .container {
     width: 420px;

--- a/_codux/ui-kit/typography/typography.board.tsx
+++ b/_codux/ui-kit/typography/typography.board.tsx
@@ -1,7 +1,7 @@
-import '~/styles/common.scss';
 import { createBoard, Variant } from '@wixc3/react-board';
-import styles from './typography.board.module.scss';
 import classNames from 'classnames';
+
+import styles from './typography.board.module.scss';
 
 export default createBoard({
     name: 'Typography',
@@ -9,7 +9,7 @@ export default createBoard({
         <div className={styles.container}>
             <div>
                 <span className={styles.uikit}>UI Kit</span>
-                <span className={styles.foundation}> | Foundation</span>
+                <span className={styles.foundation}> | Foundation</span>
                 <hr className={styles.hrSolid} />
                 <h3 className={styles.sectionTitle}>Typography</h3>
                 <h4 className={styles.sectionHeader}>DISPLAY</h4>
@@ -61,7 +61,7 @@ export default createBoard({
                 </p>
             </Variant>
             <p className={classNames(styles.variantName, styles.headlinesSpacing)}>
-                --paragraph1: <span className={styles.fontDetails}>Figtree (400) / 20px / 1.4</span>
+                --paragraph1: <span className={styles.fontDetails}>Figtree (400) / 20px / 1.4</span>
             </p>
             <Variant name="Paragraph2">
                 <p className="paragraph2">
@@ -69,7 +69,7 @@ export default createBoard({
                 </p>
             </Variant>
             <p className={classNames(styles.variantName, styles.headlinesSpacing)}>
-                --paragraph2: <span className={styles.fontDetails}>Figtree (400) / 20px / 1.4</span>
+                --paragraph2: <span className={styles.fontDetails}>Figtree (400) / 20px / 1.4</span>
             </p>
             <Variant name="Paragraph3">
                 <p className="paragraph3">
@@ -77,7 +77,7 @@ export default createBoard({
                 </p>
             </Variant>
             <p className={classNames(styles.variantName, styles.headlinesSpacing)}>
-                --paragraph3: <span className={styles.fontDetails}>Figtree (400) / 20px / 1.4</span>
+                --paragraph3: <span className={styles.fontDetails}>Figtree (400) / 20px / 1.4</span>
             </p>
         </div>
     ),

--- a/app/routes/product-details.$productSlug/product-details.module.scss
+++ b/app/routes/product-details.$productSlug/product-details.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/common.scss';
+@import '@styles/variables.scss';
 
 .page {
     padding-bottom: 3%;

--- a/app/routes/products.$categorySlug/products.module.scss
+++ b/app/routes/products.$categorySlug/products.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/common.scss';
+@import '@styles/variables.scss';
 
 .page {
     padding-bottom: 3%;

--- a/src/components/order-summary/order-item/order-item.module.scss
+++ b/src/components/order-summary/order-item/order-item.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/common.scss';
+@import '@styles/variables.scss';
 
 $imageSize: 100px;
 

--- a/src/components/order-summary/order-summary.module.scss
+++ b/src/components/order-summary/order-summary.module.scss
@@ -1,4 +1,4 @@
-@import '@styles/common.scss';
+@import '@styles/variables.scss';
 
 .root {
     width: 100%;

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,9 +1,3 @@
-/* Viewport Breakpoints *******************************************************/
-
-$mobile-width: 480px;
-$tablet-width: 768px;
-$desktop-width: 1024px;
-
 /* Headings *******************************************************************/
 
 .heading1 {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,7 +1,9 @@
 @import './reset.scss';
+@import './variables.scss';
 @import './colors.scss';
 @import './typography.scss';
 @import './common.scss';
+
 @import url('https://fonts.googleapis.com/css2?family=Marcellus&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap');
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,5 @@
+/* Viewport Breakpoints *******************************************************/
+
+$mobile-width: 480px;
+$tablet-width: 768px;
+$desktop-width: 1024px;


### PR DESCRIPTION
* Moved viewport breakpoints to `src/styles/variables.scss`
* Removed imports of `common.scss` in TS and SCSS files other than `index.scss`
* Fixed ESLint errors in boards added by non-developers.

For some reason, Codux couldn't resolve `import './variables.scss'` in `common.scss`, so as a workaround I've imported it in `index.scss` instead. (Other imports of `variables.scss` seem to work in Codux, e.g. in `order-item.module.scss`).