### PR TITLE
fix: `about us` page style tweaks

### DIFF
--- a/app/routes/about-us/about-us.module.scss
+++ b/app/routes/about-us/about-us.module.scss
@@ -26,7 +26,7 @@
 
 .description {
     font-size: 22px;
-    max-width: 75%;
+    max-width: 80%;
 }
 
 .image {
@@ -43,7 +43,7 @@
 
     .subtitle {
         font: var(--heading3);
-        max-width: 85%;
+        max-width: unset;
     }
 
     .description {
@@ -60,7 +60,6 @@
     }
 
     .subtitle {
-        max-width: unset;
         font-size: 40px;
         margin-bottom: 5%;
     }

--- a/app/routes/about-us/about-us.module.scss
+++ b/app/routes/about-us/about-us.module.scss
@@ -21,12 +21,12 @@
     font: var(--heading2);
     font-size: 60px;
     max-width: 600px;
-    margin-bottom: 8%;
+    margin-bottom: 6%;
 }
 
 .description {
     font-size: 22px;
-    max-width: 360px;
+    max-width: 75%;
 }
 
 .image {
@@ -43,7 +43,7 @@
 
     .subtitle {
         font: var(--heading3);
-        max-width: 330px;
+        max-width: 85%;
     }
 
     .description {


### PR DESCRIPTION
Tweaks description styles to look better on different screen sizes

#### Before

https://github.com/user-attachments/assets/e6d54d29-b0aa-4101-b0a8-45cc4d248e10


#### After

https://github.com/user-attachments/assets/1e90bdaa-6378-471c-b8c6-bde4785b23b9


