### PR TITLE
fix: error handling in ErrorBoundary

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -23,7 +23,7 @@ import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { ShareProductLinks } from '~/components/share-product-links/share-product-links';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
-import { removeQueryStringFromUrl } from '~/utils';
+import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
 
 import styles from './product-details.module.scss';
 
@@ -159,26 +159,22 @@ export function ErrorBoundary() {
     const error = useRouteError();
     const navigate = useNavigate();
 
-    if (isRouteErrorResponse(error)) {
-        let title: string;
-        let message: string | undefined;
-        if (error.data.code === EcomApiErrorCodes.ProductNotFound) {
-            title = 'Product Not Found';
-            message = "Unfortunately a product page you trying to open doesn't exist";
-        } else {
-            title = 'Error';
-            message = error.data.message;
-        }
-
-        return (
-            <ErrorPage
-                title={title}
-                message={message}
-                actionButtonText="Back to shopping"
-                onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
-            />
-        );
+    let title;
+    let message;
+    if (isRouteErrorResponse(error) && error.data.code === EcomApiErrorCodes.ProductNotFound) {
+        title = 'Product Not Found';
+        message = "Unfortunately, the product page you're trying to open does not exist";
+    } else {
+        title = 'Error';
+        message = getErrorMessage(error);
     }
 
-    throw error;
+    return (
+        <ErrorPage
+            title={title}
+            message={message}
+            actionButtonText="Back to shopping"
+            onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
+        />
+    );
 }

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -17,6 +17,7 @@ import { ProductLink } from '~/components/product-link/product-link';
 import { FadeIn } from '~/components/visual-effects';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
+import { getErrorMessage } from '~/utils';
 import styles from './products.module.scss';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
@@ -128,26 +129,22 @@ export function ErrorBoundary() {
     const error = useRouteError();
     const navigate = useNavigate();
 
-    if (isRouteErrorResponse(error)) {
-        let title: string;
-        let message: string | undefined;
-        if (error.data.code === EcomApiErrorCodes.CategoryNotFound) {
-            title = 'Category Not Found';
-            message = "Unfortunately, the category page you're trying to open does not exist";
-        } else {
-            title = 'Error';
-            message = error.data.message;
-        }
-
-        return (
-            <ErrorPage
-                title={title}
-                message={message}
-                actionButtonText="Back to shopping"
-                onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
-            />
-        );
+    let title;
+    let message;
+    if (isRouteErrorResponse(error) && error.data.code === EcomApiErrorCodes.CategoryNotFound) {
+        title = 'Category Not Found';
+        message = "Unfortunately, the category page you're trying to open does not exist";
+    } else {
+        title = 'Error';
+        message = getErrorMessage(error);
     }
 
-    throw error;
+    return (
+        <ErrorPage
+            title={title}
+            message={message}
+            actionButtonText="Back to shopping"
+            onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
+        />
+    );
 }


### PR DESCRIPTION
#### The problem

An error emitted from one `ErrorBoundary` won't be caught by an `ErrorBoundary` of a parent route.
Such error will break the whole application.

#### Solution

All possible errors should be handled by closest ErrorBoundary in a routes hierarchy