### PR TITLE
Revert "fix: error handling in ErrorBoundary"

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -23,7 +23,7 @@ import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { ShareProductLinks } from '~/components/share-product-links/share-product-links';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
-import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
+import { removeQueryStringFromUrl } from '~/utils';
 
 import styles from './product-details.module.scss';
 
@@ -159,22 +159,26 @@ export function ErrorBoundary() {
     const error = useRouteError();
     const navigate = useNavigate();
 
-    let title;
-    let message;
-    if (isRouteErrorResponse(error) && error.data.code === EcomApiErrorCodes.ProductNotFound) {
-        title = 'Product Not Found';
-        message = "Unfortunately, the product page you're trying to open does not exist";
-    } else {
-        title = 'Error';
-        message = getErrorMessage(error);
+    if (isRouteErrorResponse(error)) {
+        let title: string;
+        let message: string | undefined;
+        if (error.data.code === EcomApiErrorCodes.ProductNotFound) {
+            title = 'Product Not Found';
+            message = "Unfortunately a product page you trying to open doesn't exist";
+        } else {
+            title = 'Error';
+            message = error.data.message;
+        }
+
+        return (
+            <ErrorPage
+                title={title}
+                message={message}
+                actionButtonText="Back to shopping"
+                onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
+            />
+        );
     }
 
-    return (
-        <ErrorPage
-            title={title}
-            message={message}
-            actionButtonText="Back to shopping"
-            onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
-        />
-    );
+    throw error;
 }

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -17,7 +17,6 @@ import { ProductLink } from '~/components/product-link/product-link';
 import { FadeIn } from '~/components/visual-effects';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
-import { getErrorMessage } from '~/utils';
 import styles from './products.module.scss';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
@@ -129,22 +128,26 @@ export function ErrorBoundary() {
     const error = useRouteError();
     const navigate = useNavigate();
 
-    let title;
-    let message;
-    if (isRouteErrorResponse(error) && error.data.code === EcomApiErrorCodes.CategoryNotFound) {
-        title = 'Category Not Found';
-        message = "Unfortunately, the category page you're trying to open does not exist";
-    } else {
-        title = 'Error';
-        message = getErrorMessage(error);
+    if (isRouteErrorResponse(error)) {
+        let title: string;
+        let message: string | undefined;
+        if (error.data.code === EcomApiErrorCodes.CategoryNotFound) {
+            title = 'Category Not Found';
+            message = "Unfortunately, the category page you're trying to open does not exist";
+        } else {
+            title = 'Error';
+            message = error.data.message;
+        }
+
+        return (
+            <ErrorPage
+                title={title}
+                message={message}
+                actionButtonText="Back to shopping"
+                onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
+            />
+        );
     }
 
-    return (
-        <ErrorPage
-            title={title}
-            message={message}
-            actionButtonText="Back to shopping"
-            onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
-        />
-    );
+    throw error;
 }


### PR DESCRIPTION
This reverts commit ad9195c825741164cce9e98216b6f2c070dc797b.

The assumption I described in this PR is not correct, errors emitted by nested error boundaries handled correctly.

The problem is in `getErrorMessage` function and i will fix it in next PR.
it returns an object in case when an error is `ErrorResponse`  