### PR TITLE
fix: center header text on the error page

### DIFF
--- a/src/components/error-page/error-page.module.scss
+++ b/src/components/error-page/error-page.module.scss
@@ -8,6 +8,7 @@
     justify-content: center;
     align-items: center;
     gap: 24px;
+    text-align: center;
 }
 
 .title {


### PR DESCRIPTION
The header div was centered, but the text in the div was not. The issue was only visible with long text.

Before:

<img width="563" alt="Screenshot 2024-09-23 at 17 54 31" src="https://github.com/user-attachments/assets/8fb58110-3dc1-4944-b3bd-57e40e52b215">

After:

<img width="580" alt="Screenshot 2024-09-23 at 17 54 11" src="https://github.com/user-attachments/assets/ee6a9da8-957f-46a1-b8f3-2eb3181dafce">
