### PR TITLE
fix: getErrorMessage returns an object in case of ErrorResponse

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -39,7 +39,9 @@ export function getErrorMessage(value: unknown): string {
     }
 
     if (isRouteErrorResponse(value)) {
-        return value.data.message;
+        if (typeof value.data === 'string') return value.data;
+        else if (typeof value.data.message === 'string') return value.data.message;
+        else return String(value.data);
     }
 
     if (isEcomSDKError(value)) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -39,7 +39,7 @@ export function getErrorMessage(value: unknown): string {
     }
 
     if (isRouteErrorResponse(value)) {
-        return value.data;
+        return value.data.message;
     }
 
     if (isEcomSDKError(value)) {


### PR DESCRIPTION
#### Problem
In case of `ErrorResponse` emitted by route loader, `getErrorMessage` function return an object instead of a string.
