### PR TITLE
fix: fix hydration failed error

### DIFF
--- a/_codux/boards/breadcrumbs.board.tsx
+++ b/_codux/boards/breadcrumbs.board.tsx
@@ -1,0 +1,31 @@
+import { createBoard } from '@wixc3/react-board';
+import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
+import ComponentWrapper from '../board-wrappers/component-wrapper';
+
+export default createBoard({
+    name: 'Breadcrumbs',
+    Board: () => (
+        <ComponentWrapper>
+            <Breadcrumbs
+                breadcrumbs={[
+                    {
+                        title: 'Home',
+                        to: '/',
+                    },
+                    {
+                        title: 'All Products',
+                        to: '/products/all-products',
+                    },
+                    {
+                        title: 'Lemongrass Natural Soap',
+                        to: '/product-details/lemongrass-natural-soap',
+                    },
+                ]}
+            />
+        </ComponentWrapper>
+    ),
+    environmentProps: {
+        windowWidth: 400,
+        windowHeight: 100,
+    },
+});

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,5 @@
 import {
     isRouteErrorResponse,
-    Link,
     Links,
     Meta,
     type MetaFunction,
@@ -39,7 +38,7 @@ export async function loader() {
 }
 
 export const handle: RouteHandle = {
-    breadcrumb: () => <Link to={ROUTES.home.path}>Home</Link>,
+    breadcrumbs: () => [{ title: 'Home', to: ROUTES.home.path }],
 };
 
 export function Layout({ children }: React.PropsWithChildren) {

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -18,6 +18,7 @@ import { FadeIn } from '~/components/visual-effects';
 import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
 import styles from './products.module.scss';
+import { useBreadcrumbs } from '~/router/use-breadcrumbs';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
     const categorySlug = params.categorySlug;
@@ -50,19 +51,21 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 };
 
 export const handle: RouteHandle<typeof loader> = {
-    breadcrumb: (match) => (
-        <CategoryLink categorySlug={match.data.category.slug!}>
-            {match.data.category.name!}
-        </CategoryLink>
-    ),
+    breadcrumbs: (match) => [
+        {
+            title: match.data.category.name!,
+            to: ROUTES.products.to(match.data.category.slug!),
+        },
+    ],
 };
 
 export default function ProductsPage() {
     const { category, categoryProducts, allCategories } = useLoaderData<typeof loader>();
+    const breadcrumbs = useBreadcrumbs();
 
     return (
         <div className={styles.page}>
-            <Breadcrumbs />
+            <Breadcrumbs breadcrumbs={breadcrumbs} />
 
             <div className={styles.content}>
                 <nav className={styles.navigation}>

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,25 +1,33 @@
 import React from 'react';
-import { useLocation, useMatches } from '@remix-run/react';
-import { RouteMatch } from '~/router/types';
+import { Link } from '@remix-run/react';
+import { BreadcrumbData } from '~/router/types';
 import styles from './breadcrumbs.module.scss';
 import { ChevronRightIcon } from '~/components/icons';
+import { ClientOnly } from 'remix-utils/client-only';
 
-export const Breadcrumbs = () => {
-    const matches = useMatches() as RouteMatch[];
-    const location = useLocation();
+interface BreadcrumbsProps {
+    breadcrumbs: BreadcrumbData[];
+}
 
+export const Breadcrumbs = ({ breadcrumbs }: BreadcrumbsProps) => {
     return (
         <div className={styles.breadcrumbs}>
-            {matches
-                .flatMap((match) => match.handle?.breadcrumb?.(match, location) ?? [])
-                .map((breadcrumb, index, arr) => (
-                    <React.Fragment key={index}>
-                        {breadcrumb}
+            {breadcrumbs.map((breadcrumb, index, arr) => {
+                const content = (
+                    <React.Fragment key={breadcrumb.to}>
+                        <Link to={breadcrumb.to}>{breadcrumb.title}</Link>
                         {index !== arr.length - 1 && (
                             <ChevronRightIcon className={styles.separatorIcon} />
                         )}
                     </React.Fragment>
-                ))}
+                );
+
+                if (breadcrumb.clientOnly) {
+                    return <ClientOnly key={breadcrumb.to}>{() => content}</ClientOnly>;
+                }
+
+                return content;
+            })}
         </div>
     );
 };

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -1,11 +1,21 @@
 import type { UIMatch, Location } from '@remix-run/react';
 
+export interface BreadcrumbData {
+    title: string;
+    to: string;
+    /**
+     * If true, renders the breadcrumb link and the separator icon only on the client side.
+     * Useful when the breadcrumb is displayed based on the client-side data, e.g. browser history.
+     */
+    clientOnly?: boolean;
+}
+
 export type RouteHandle<Data = unknown, LocationState = unknown> =
     | {
-          breadcrumb?: (
+          breadcrumbs?: (
               match: RouteMatch<Data>,
               location: Location<LocationState>
-          ) => React.ReactNode;
+          ) => BreadcrumbData[];
       }
     | undefined;
 

--- a/src/router/use-breadcrumbs.ts
+++ b/src/router/use-breadcrumbs.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import { useLocation, useMatches } from '@remix-run/react';
+import { BreadcrumbData, RouteMatch } from './types';
+
+export function useBreadcrumbs(): BreadcrumbData[] {
+    const matches = useMatches() as RouteMatch[];
+    const location = useLocation();
+
+    return useMemo(
+        () => matches.flatMap((match) => match.handle?.breadcrumbs?.(match, location) ?? []),
+        [matches, location]
+    );
+}


### PR DESCRIPTION
On the product details page the category breadcrumb is added on the client-side (based on the history state).
The hydration failed because of that.
 
<img width="1028" alt="Screenshot 2024-09-23 at 18 08 12" src="https://github.com/user-attachments/assets/8d1bac49-f033-4271-b3db-24ab488e2adb">
<br /><br />

I fixed this error using `ClientOnly` component but I had to rewrite breadcrumbs a bit.
Also, I added `Breadcrumbs` board.
