### PR TITLE
fix: improve handling of React Router's ErrorResponse in  getErrorMessage

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -21,7 +21,7 @@ import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { ShareProductLinks } from '~/components/share-product-links/share-product-links';
 import { ROUTES } from '~/router/config';
 import { BreadcrumbData, RouteHandle } from '~/router/types';
-import { removeQueryStringFromUrl } from '~/utils';
+import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
 import styles from './product-details.module.scss';
 import { useBreadcrumbs } from '~/router/use-breadcrumbs';
 
@@ -160,26 +160,20 @@ export function ErrorBoundary() {
     const error = useRouteError();
     const navigate = useNavigate();
 
-    if (isRouteErrorResponse(error)) {
-        let title: string;
-        let message: string | undefined;
-        if (error.data.code === EcomApiErrorCodes.ProductNotFound) {
-            title = 'Product Not Found';
-            message = "Unfortunately a product page you trying to open doesn't exist";
-        } else {
-            title = 'Error';
-            message = error.data.message;
-        }
+    let title = 'Error';
+    let message = getErrorMessage(error);
 
-        return (
-            <ErrorPage
-                title={title}
-                message={message}
-                actionButtonText="Back to shopping"
-                onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
-            />
-        );
+    if (isRouteErrorResponse(error) && error.data.code === EcomApiErrorCodes.ProductNotFound) {
+        title = 'Product Not Found';
+        message = "Unfortunately a product page you trying to open doesn't exist";
     }
 
-    throw error;
+    return (
+        <ErrorPage
+            title={title}
+            message={message}
+            actionButtonText="Back to shopping"
+            onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
+        />
+    );
 }

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -173,7 +173,7 @@ export function ErrorBoundary() {
             title={title}
             message={message}
             actionButtonText="Back to shopping"
-            onActionButtonClick={() => navigate(ROUTES.products.to('all-producs'))}
+            onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
         />
     );
 }

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -19,6 +19,7 @@ import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
 import styles from './products.module.scss';
 import { useBreadcrumbs } from '~/router/use-breadcrumbs';
+import { getErrorMessage } from '~/utils';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
     const categorySlug = params.categorySlug;
@@ -131,26 +132,20 @@ export function ErrorBoundary() {
     const error = useRouteError();
     const navigate = useNavigate();
 
-    if (isRouteErrorResponse(error)) {
-        let title: string;
-        let message: string | undefined;
-        if (error.data.code === EcomApiErrorCodes.CategoryNotFound) {
-            title = 'Category Not Found';
-            message = "Unfortunately, the category page you're trying to open does not exist";
-        } else {
-            title = 'Error';
-            message = error.data.message;
-        }
+    let title = 'Error';
+    let message = getErrorMessage(error);
 
-        return (
-            <ErrorPage
-                title={title}
-                message={message}
-                actionButtonText="Back to shopping"
-                onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
-            />
-        );
+    if (isRouteErrorResponse(error) && error.data.code === EcomApiErrorCodes.CategoryNotFound) {
+        title = 'Category Not Found';
+        message = "Unfortunately, the category page you're trying to open does not exist";
     }
 
-    throw error;
+    return (
+        <ErrorPage
+            title={title}
+            message={message}
+            actionButtonText="Back to shopping"
+            onActionButtonClick={() => navigate(ROUTES.products.to('all-products'))}
+        />
+    );
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,10 +38,17 @@ export function getErrorMessage(value: unknown): string {
         return value.message;
     }
 
+    // If the thrown error is an instance of Error, React Router will convert it to a string.
+    // If it's a JSON response like throw json({ message: "error" }) it will parse that JSON into ErrorResponse.data.
     if (isRouteErrorResponse(value)) {
-        if (typeof value.data === 'string') return value.data;
-        else if (typeof value.data.message === 'string') return value.data.message;
-        else return String(value.data);
+        const data: unknown = value.data;
+        if (typeof data === 'string') return data;
+        if (data === null) return '';
+
+        if (typeof data === 'object' && 'message' in data && typeof data.message === 'string')
+            return data.message;
+
+        return String(data);
     }
 
     if (isEcomSDKError(value)) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,39 +29,39 @@ export function removeQueryStringFromUrl(url: string) {
  * Retrieves the message from a thrown error.
  * - Handles Remix ErrorResponse (non-Error instance).
  * - Handles Wix eCom SDK errors (non-Error instance).
- * - Converts plain objects to a JSON string as a measure
- *   to help identify the origin of such improper errors.
- * - Falls back on converting the value to a string.
+ * - Handles plain objects structured like an Error.
+ * - Converts plain objects with unknown structure into
+ *   a JSON string to help in debugging their source.
+ * - Falls back to converting the value to a string.
  */
-export function getErrorMessage(value: unknown): string {
-    if (value instanceof Error) {
-        return value.message;
+export function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
     }
 
-    // If the thrown error is an instance of Error, React Router will convert it to a string.
-    // If it's a JSON response like throw json({ message: "error" }) it will parse that JSON into ErrorResponse.data.
-    if (isRouteErrorResponse(value)) {
-        const data: unknown = value.data;
-        if (typeof data === 'string') return data;
-        if (data === null) return '';
-
-        if (typeof data === 'object' && 'message' in data && typeof data.message === 'string')
-            return data.message;
-
-        return String(data);
+    if (isEcomSDKError(error)) {
+        return error.message;
     }
 
-    if (isEcomSDKError(value)) {
-        return value.message;
+    // Remix ErrorResponse thrown from an action or loader:
+    // - throw new Response('oops');
+    // - throw json('oops')
+    // - throw json({message: 'oops'})
+    if (isRouteErrorResponse(error)) {
+        error = error.data;
     }
 
-    if (typeof value == 'object' && value !== null) {
+    if (typeof error == 'object' && error !== null) {
+        if ('message' in error && typeof error.message === 'string') {
+            return error.message;
+        }
+
         try {
-            return JSON.stringify(value);
+            return JSON.stringify(error);
         } catch {
-            // ignore serialization failure
+            // Fall through.
         }
     }
 
-    return String(value);
+    return String(error);
 }


### PR DESCRIPTION
* Correctly extract the error message when one of the following patterns is used:
    * `throw new Response('oops')`
    * `throw json('oops')`
    * `throw json({message: 'oops'})`

* Update function description
* Update `ErrorBoundary` for the product page and category page to use `getErrorMessage`.