### PR TITLE
fix: remove json utility in product details loader

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -35,10 +35,10 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
         throw json(productResponse.error);
     }
 
-    return json({
+    return {
         product: productResponse.body,
         canonicalUrl: removeQueryStringFromUrl(request.url),
-    });
+    };
 };
 
 interface ProductDetailsLocationState {


### PR DESCRIPTION
To be honest I don't understand why using `json()` utility breaks it in Codux 🤷‍♂️ . `product` ends up being `undefined` on the client-side. I removed it and it fixed the problem. + We don't use it in all other route loaders. 


Before 
<img width="1728" alt="Screenshot 2024-09-24 at 12 09 56" src="https://github.com/user-attachments/assets/d8ef2d9a-f8af-4bc5-ab0b-f771efe8c89b">

