### PR TITLE
Remove focus shadow from .button:focus

### DIFF
--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -64,9 +64,6 @@
 }
 
 .button:focus {
-    box-shadow:
-        0 0 0 1px #ffffff,
-        0 0 0 3px #116dff;
 }
 
 .button:not(:disabled):hover {


### PR DESCRIPTION
<img width="486" alt="image" src="https://github.com/user-attachments/assets/605d38db-743b-4c27-b4d4-8bf7b74fd360">

