### PR TITLE
fix: add keyboard focus for links and other focusable elements

### DIFF
--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -63,12 +63,6 @@
     cursor: default;
 }
 
-.button:focus {
-    box-shadow:
-        0 0 0 1px #ffffff,
-        0 0 0 3px #116dff;
-}
-
 .button:not(:disabled):hover {
     background-color: var(--colorA5);
     color: var(--colorA1);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -20,3 +20,9 @@ body {
     min-height: 100vh;
     background-color: var(--colorA1);
 }
+
+:focus-visible {
+    box-shadow:
+        0 0 0 1px #ffffff,
+        0 0 0 3px #116dff;
+}


### PR DESCRIPTION
Add keyboard focus for links. Previously we only had keyboard focus for buttons.

---

<img width="382" alt="image" src="https://github.com/user-attachments/assets/e9bf862c-3afc-4388-a433-815996596380">

---

<img width="423" alt="image" src="https://github.com/user-attachments/assets/36296a15-a1b1-4e81-bcf6-b5afcd8235bc">

---

<img width="953" alt="image" src="https://github.com/user-attachments/assets/af8dc3bc-d169-4e58-b4ea-4e3cf1a11b36">
