### PR TITLE
fix: keyboard focus outline on product cards

### DIFF
--- a/app/routes/products.$categorySlug/route.module.scss
+++ b/app/routes/products.$categorySlug/route.module.scss
@@ -59,6 +59,10 @@
     gap: 20px 4px;
 }
 
+.productLink {
+    display: block;
+}
+
 @media (max-width: $desktop-width) {
     .productsList {
         --minCardSize: 250px;

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -19,6 +19,7 @@ import { ROUTES } from '~/router/config';
 import { RouteHandle } from '~/router/types';
 import { useBreadcrumbs } from '~/router/use-breadcrumbs';
 import { getErrorMessage } from '~/utils';
+
 import styles from './route.module.scss';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
@@ -104,6 +105,7 @@ export default function ProductsPage() {
                         {categoryProducts.map((product) => (
                             <FadeIn key={product._id} duration={0.9}>
                                 <ProductLink
+                                    className={styles.productLink}
                                     productSlug={product.slug!}
                                     state={{
                                         fromCategory: {


### PR DESCRIPTION
### Before

You can see a tiny blue square in the top left corner of the first card. That's keyboard focus outline. It doesn't cover the entire card because the `<a>` element has `display: inline`.

<img src="https://github.com/user-attachments/assets/23931a92-49ce-4939-af21-d5c370882b58" width="500">

---

### After
<img src="https://github.com/user-attachments/assets/22c25f0b-0e49-4832-b2e5-85e85c15dea3" width="500">
