### PR TITLE
fix: don't clip focus outline in featured products section

### DIFF
--- a/src/components/visual-effects/reveal.tsx
+++ b/src/components/visual-effects/reveal.tsx
@@ -23,7 +23,11 @@ export const Reveal: FC<RevealProps> = ({ direction = 'down', duration = 1.4, ..
                 left: 'inset(0 0 0 100%)',
             }[direction],
         }}
-        whileInView={{ clipPath: 'none' }}
+        whileInView={{
+            clipPath: 'inset(0 0 0 0)',
+            // Prevent clipping outline and box-shadow after transition.
+            transitionEnd: { clipPath: '' },
+        }}
         viewport={{ once: true }}
         {...props}
     />


### PR DESCRIPTION
### Before

(The second card has keyboard focus)

<img width="610" alt="Screenshot 2024-09-24 at 19 06 51" src="https://github.com/user-attachments/assets/0bab629c-8694-4172-abb0-3c394e3c70e3">

---

### After

<img width="610" alt="Screenshot 2024-09-24 at 19 06 30" src="https://github.com/user-attachments/assets/766839ba-9fd9-42e5-97da-0f952ea4b6e2">
