### PR TITLE
feat: skeletons for the featured products section

### DIFF
--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import useSWR from 'swr';
 import { getEcomApi } from '~/api/ecom-api';
 import { CollectionDetails, isEcomSDKError } from '~/api/types';
-import { ProductCard } from '~/components/product-card/product-card';
+import { ProductCard, ProductCardSkeleton } from '~/components/product-card/product-card';
 import { ProductLink } from '~/components/product-link/product-link';
 import { FadeIn, Reveal } from '~/components/visual-effects';
 
@@ -67,20 +67,22 @@ export const FeaturedProductsSection = (props: FeaturedProductsSectionProps) => 
                     {description ?? data?.category.description}
                 </div>
             </FadeIn>
-            {data && (
-                <Reveal direction="down" className={styles.productsRow}>
-                    {data.products.map((product) => (
-                        <ProductLink key={product._id} productSlug={product.slug!}>
-                            <ProductCard
-                                name={product.name!}
-                                imageUrl={product.media?.mainMedia?.image?.url}
-                                priceData={product.priceData}
-                                ribbon={product.ribbon ?? undefined}
-                            />
-                        </ProductLink>
-                    ))}
-                </Reveal>
-            )}
+            <Reveal direction="down" className={styles.productsRow}>
+                {data
+                    ? data.products.map((product) => (
+                          <ProductLink key={product._id} productSlug={product.slug!}>
+                              <ProductCard
+                                  name={product.name!}
+                                  imageUrl={product.media?.mainMedia?.image?.url}
+                                  priceData={product.priceData}
+                                  ribbon={product.ribbon ?? undefined}
+                              />
+                          </ProductLink>
+                      ))
+                    : Array.from({ length: productCount }).map((_, i) => (
+                          <ProductCardSkeleton key={i} />
+                      ))}
+            </Reveal>
         </div>
     );
 };

--- a/src/components/product-card/product-card.module.scss
+++ b/src/components/product-card/product-card.module.scss
@@ -46,3 +46,7 @@
 .outOfStock {
     color: var(--colorA4);
 }
+
+.skeleton > .imageWrapper {
+    background-color: #f1ede7;
+}

--- a/src/components/product-card/product-card.tsx
+++ b/src/components/product-card/product-card.tsx
@@ -42,10 +42,8 @@ export const ProductCard = ({
 };
 
 export const ProductCardSkeleton = () => (
-    <div>
-        <div className={styles.imageWrapper}>
-            <ImagePlaceholderIcon className={styles.imagePlaceholderIcon} />
-        </div>
+    <div className={styles.skeleton}>
+        <div className={styles.imageWrapper} />
         <div className={styles.name}>&nbsp;</div>
         <div className={styles.price}>&nbsp;</div>
     </div>

--- a/src/components/product-card/product-card.tsx
+++ b/src/components/product-card/product-card.tsx
@@ -40,3 +40,13 @@ export const ProductCard = ({
         </div>
     );
 };
+
+export const ProductCardSkeleton = () => (
+    <div>
+        <div className={styles.imageWrapper}>
+            <ImagePlaceholderIcon className={styles.imagePlaceholderIcon} />
+        </div>
+        <div className={styles.name}>&nbsp;</div>
+        <div className={styles.price}>&nbsp;</div>
+    </div>
+);


### PR DESCRIPTION
Since the `<FeaturedProductsSection>` is loaded on the client, sometimes there's an unpleasant page jump if you scroll before this section has loaded.

I've added skeletons that normally won't be visible, you have to scroll down to the products section fast enough. I wasn't sure whether to pass dummy data into the `<ProductCard>` component, or to add a prop `skeleton={true}` or to implement a separate `<ProductCardSkeleton>`.

https://github.com/user-attachments/assets/c2d73c98-95c3-4d64-a70b-9321073f98bb



