### PR TITLE
refactor: simplify styling of the text banner

### DIFF
--- a/_codux/boards/text-banner.board.tsx
+++ b/_codux/boards/text-banner.board.tsx
@@ -18,6 +18,6 @@ export default createBoard({
     ),
     environmentProps: {
         windowWidth: 600,
-        windowHeight: 220,
+        windowHeight: 260,
     },
 });

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -186,63 +186,33 @@
 
 .textBannerSection {
     min-height: 35vw;
+    padding: 50px 10px;
     align-content: center;
 }
 
 .textBanner {
-    padding: 0 14%;
+    max-width: max(60vw, 500px);
+    margin: 0 auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
+    place-items: center;
     text-align: center;
-}
-
-.textBannerSubtitle {
     font-family: var(--text-font);
-    line-height: 1.4;
-    font-size: max(1.3vw, 16px);
-    text-transform: uppercase;
-    white-space: nowrap;
-    margin-bottom: 1%;
+    line-height: 1;
 }
 
 .textBannerTitle {
-    font: var(--heading2);
-    font-size: 4.3vw;
-    line-height: 1.1em;
-    margin-bottom: 1%;
+    margin-bottom: 10px;
+    font-family: var(--heading-font);
+    font-size: max(30px, 4.3vw);
+    line-height: 1.1;
 }
 
-@media (max-width: $desktop-width) {
-    .textBanner {
-        padding: 70px 14%;
-    }
-
-    .textBannerSubtitle {
-        font-size: 1.8vw;
-        margin-bottom: 2%;
-    }
-}
-
-@media (max-width: $tablet-width) {
-    .textBanner {
-        padding: 70px 0;
-    }
-
-    .textBannerSubtitle {
-        font-size: 14px;
-    }
-
-    .textBannerTitle {
-        font-size: 6.3vw;
-    }
-}
-
-@media (max-width: $mobile-width) {
-    .textBannerTitle {
-        font-size: 30px;
-    }
+.textBannerSubtitle {
+    margin-bottom: 15px;
+    font-size: max(14px, 1.45vw);
+    text-transform: uppercase;
+    white-space: nowrap;
 }
 
 /* Link Card ******************************************************************/


### PR DESCRIPTION
1. I don't see a need to override the styling of this block for different breakpoints, it scales down nicely without any special adjustments.

2. Padding was handled inconsistently: at the desktop size, the vertical padding came from `.textBannerSection`, but at the tablet/mobile size, it switched to `.textBanner` for no apparent reason. _(In principle, we could even remove `.textBannerSection` and put its styles on the `.textBanner` instead.)_

I didn't aim for a pixel-perfect reproduction of the original template, but it's very close at both desktop and mobile sizes.

---

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/5f10dfe1-f6d5-4f69-8fdc-80e4d07a2198">

---

<img width="500" alt="image" src="https://github.com/user-attachments/assets/557fb639-f753-4c65-a7d7-4ebeaac842da">

