### PR TITLE
fix: tweak page padding and header font size on mobile

### DIFF
--- a/src/components/header/header.module.scss
+++ b/src/components/header/header.module.scss
@@ -18,6 +18,7 @@
     justify-content: space-between;
     gap: 8px;
     border-bottom: 1px solid var(--black);
+    font: var(--paragraph3);
 }
 
 .logo {
@@ -28,7 +29,6 @@
 .advertisingText {
     display: inline-block;
     margin-right: 16px;
-    font: var(--paragraph3);
     white-space: nowrap;
 }
 
@@ -66,7 +66,6 @@
 
 .shopNow {
     text-align: center;
-    font: var(--paragraph3);
     line-height: 1;
     color: var(--black);
     padding: 3px 11px 4px;
@@ -114,5 +113,6 @@
         flex-direction: column-reverse;
         align-items: start;
         justify-content: center;
+        font-size: 13px;
     }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,7 +6,7 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -webkit-text-size-adjust: 100%;
-    --pagePaddingHoriz: 2vw;
+    --pagePaddingHoriz: max(2vw, 15px);
 }
 
 body {


### PR DESCRIPTION
Checked the site on my phone (375px × 812px) and the horizontal page padding (2vw) did in fact look weird. I've set the minimum at 15px.

Also noticed that the header looks wonky. Adjusted the font size at mobile breakpoint to match the original template.

Before and after:

<img width="795" alt="image" src="https://github.com/user-attachments/assets/59583e67-41aa-4755-b04e-3acdb62b61ad">
