### PR TITLE
feat: make footer responsive

### DIFF
--- a/src/components/footer/footer.module.scss
+++ b/src/components/footer/footer.module.scss
@@ -1,3 +1,5 @@
+@import '@styles/variables.scss';
+
 .root {
     padding: 30px var(--pagePaddingHoriz);
     background-color: var(--colorA3);
@@ -5,10 +7,9 @@
 
 .navigation {
     display: flex;
-    align-items: start;
-    justify-content: start;
-    gap: 150px;
-    padding-bottom: 30px;
+    flex-wrap: wrap;
+    gap: 20px 10vw;
+    margin-bottom: 50px;
 }
 
 .navItem {
@@ -27,6 +28,7 @@
     display: flex;
     align-items: baseline;
     justify-content: space-between;
+    flex-wrap: wrap;
 }
 
 .logo {
@@ -42,4 +44,16 @@
 
 .coduxLink {
     text-decoration: underline;
+}
+
+@media (max-width: $tablet-width) {
+    .navigation {
+        justify-content: space-between;
+    }
+}
+
+@media (max-width: $mobile-width) {
+    .navigation {
+        gap: 20px 100px;
+    }
 }


### PR DESCRIPTION
Desktop:
<img width="1195" alt="Screenshot 2024-09-25 at 11 01 19" src="https://github.com/user-attachments/assets/b5ce508c-9d5a-48b1-9cea-28d3635c368d">


Tablet:
<img width="833" alt="Screenshot 2024-09-25 at 11 01 34" src="https://github.com/user-attachments/assets/a8e9361b-a422-4dfd-96b2-29cae797507a">


Mobile:
It is not quite the same like on the wix template, but looks good for me.
<img width="379" alt="Screenshot 2024-09-25 at 11 01 55" src="https://github.com/user-attachments/assets/005fa6ce-82fd-453d-a0ce-78ec15020002">



## Edge case
If the text of the second column is quite small then the footer has a big space in the center:
<img width="426" alt="Screenshot 2024-09-25 at 11 21 02" src="https://github.com/user-attachments/assets/1e6ad344-3c28-4b08-9f67-68b0fa6aefb0">
1. I can add some `padding-right` to navigation section for mobile
2. We can leave it on user. If they have narrow text there, let they add the indent. I would choose this option.