### PR TITLE
refactor: simplify product price props

### DIFF
--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -52,10 +52,7 @@ export default createBoard({
                     name="Bamboo Toothbrush"
                     imageUrl="https://static.wixstatic.com/media/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg/v1/fill/w_824,h_1098,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg"
                     ribbon="NEW"
-                    priceData={{
-                        currency: '$',
-                        price: 5.5,
-                    }}
+                    price="$5.5"
                 />
                 <span className={styles.fontDetails}>Product Card</span>
                 <h4>Product gallery missing</h4>

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -107,7 +107,11 @@ export default function ProductDetailsPage() {
                     {product.sku && <p className={styles.sku}>SKU: {product.sku}</p>}
 
                     {product.priceData && (
-                        <ProductPrice priceData={product.priceData} className={styles.price} />
+                        <ProductPrice
+                            className={styles.price}
+                            price={product.priceData.formatted?.price}
+                            discountedPrice={product.priceData.formatted?.discountedPrice}
+                        />
                     )}
 
                     {product.description && (

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -117,7 +117,10 @@ export default function ProductsPage() {
                                     <ProductCard
                                         name={product.name!}
                                         imageUrl={product.media?.mainMedia?.image?.url}
-                                        priceData={product.priceData}
+                                        price={product.priceData?.formatted?.price}
+                                        discountedPrice={
+                                            product.priceData?.formatted?.discountedPrice
+                                        }
                                         ribbon={product.ribbon ?? undefined}
                                         inventoryStatus={product.stock?.inventoryStatus}
                                     />

--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -74,7 +74,8 @@ export const FeaturedProductsSection = (props: FeaturedProductsSectionProps) => 
                               <ProductCard
                                   name={product.name!}
                                   imageUrl={product.media?.mainMedia?.image?.url}
-                                  priceData={product.priceData}
+                                  price={product.priceData?.formatted?.price}
+                                  discountedPrice={product.priceData?.formatted?.discountedPrice}
                                   ribbon={product.ribbon ?? undefined}
                               />
                           </ProductLink>

--- a/src/components/product-card/product-card.tsx
+++ b/src/components/product-card/product-card.tsx
@@ -6,7 +6,15 @@ import { ImagePlaceholderIcon } from '../icons';
 interface ProductCardProps {
     name: string;
     imageUrl?: string;
-    priceData?: products.PriceData;
+    /**
+     * Product price formatted with the currency.
+     */
+    price?: string;
+    /**
+     * Discounted product price formatted with the currency.
+     * It is displayed if it's not equal to the main price.
+     */
+    discountedPrice?: string;
     ribbon?: string;
     inventoryStatus?: products.InventoryStatus;
 }
@@ -14,7 +22,8 @@ interface ProductCardProps {
 export const ProductCard = ({
     name,
     imageUrl,
-    priceData,
+    price,
+    discountedPrice,
     ribbon,
     inventoryStatus,
 }: ProductCardProps) => {
@@ -35,7 +44,11 @@ export const ProductCard = ({
             {inventoryStatus === products.InventoryStatus.OUT_OF_STOCK ? (
                 <div className={styles.outOfStock}>Out of stock</div>
             ) : (
-                priceData && <ProductPrice priceData={priceData} className={styles.price} />
+                <ProductPrice
+                    className={styles.price}
+                    price={price}
+                    discountedPrice={discountedPrice}
+                />
             )}
         </div>
     );

--- a/src/components/product-price/product-price.tsx
+++ b/src/components/product-price/product-price.tsx
@@ -1,23 +1,18 @@
-import { products } from '@wix/stores';
-import styles from './product-price.module.scss';
 import classNames from 'classnames';
+import styles from './product-price.module.scss';
 
 interface ProductPriceProps {
-    priceData: products.PriceData;
+    price?: string;
+    discountedPrice?: string;
     className?: string;
 }
 
-export const ProductPrice = ({ priceData, className }: ProductPriceProps) => {
-    if (!priceData.formatted) return null;
-    const hasDiscount = priceData.price !== priceData.discountedPrice;
+export const ProductPrice = ({ price, discountedPrice, className }: ProductPriceProps) => {
+    const hasDiscount = price !== discountedPrice;
     return (
         <div className={classNames(styles.root, className)}>
-            {hasDiscount && (
-                <span className={styles.beforeDiscount}>{priceData.formatted.price}</span>
-            )}
-            <span>
-                {hasDiscount ? priceData.formatted.discountedPrice : priceData.formatted.price}
-            </span>
+            {hasDiscount && <span className={styles.beforeDiscount}>{price}</span>}
+            <span>{hasDiscount ? discountedPrice : price}</span>
         </div>
     );
 };


### PR DESCRIPTION
It's not convinient to work with the full `priceData` object in the props panel in Codux. It's not very clear what data should be passed to see the price in the product card, especially for designers.
It's better to have more primitive props: `price: string` and `discountedPrice: string`.