### PR TITLE
refactor: rename cardGroup to cardsSection

### DIFF
--- a/_codux/boards/link-cards.board.tsx
+++ b/_codux/boards/link-cards.board.tsx
@@ -3,7 +3,7 @@ import { createBoard } from '@wixc3/react-board';
 export default createBoard({
     name: 'Link Cards',
     Board: () => (
-        <div className="cardGroup">
+        <div className="cardsSection">
             <a className="linkCard" href="about:blank">
                 <img
                     className="linkCardBackground"
@@ -31,7 +31,7 @@ export default createBoard({
         </div>
     ),
     environmentProps: {
-        windowWidth: 600,
-        windowHeight: 270,
+        windowWidth: 800,
+        windowHeight: 390,
     },
 });

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -33,7 +33,7 @@ export default function HomePage() {
                 </FadeIn>
             </div>
 
-            <div className="cardGroup">
+            <div className="cardsSection">
                 <CategoryLink categorySlug="kitchen-essentials" className="linkCard">
                     <img
                         className="linkCardBackground"

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -336,26 +336,26 @@
     }
 }
 
-/* Card Group *****************************************************************/
+/* Cards Section **************************************************************/
 
-.cardGroup {
+.cardsSection {
     display: flex;
     gap: 4px;
     margin-bottom: 5%;
 }
 
-.cardGroup > * {
+.cardsSection > * {
     aspect-ratio: 0.75;
     flex: 1 1 0;
 }
 
 @media (max-width: $tablet-width) {
-    .cardGroup {
+    .cardsSection {
         flex-direction: column;
         gap: 8px;
     }
 
-    .cardGroup > * {
+    .cardsSection > * {
         flex: 0;
     }
 }


### PR DESCRIPTION
Renamed `.cardGroup` to `.cardsSection` because it has a margin that only makes sense in the context of a section of the page.

Fixed the board with link cards which was showing cards in a single column instead of side by side because of a media query. Looks like this now:

<img width="492" alt="image" src="https://github.com/user-attachments/assets/3f892882-f1bf-48e0-bb33-ca8d7846b1cc">
