### PR TITLE
fix: remove blue focus outline from quantity input

### DIFF
--- a/src/components/quantity-input/quantity-input.module.scss
+++ b/src/components/quantity-input/quantity-input.module.scss
@@ -40,3 +40,7 @@
 .input:disabled {
     color: var(--colorA3);
 }
+
+.input:focus-visible {
+    box-shadow: none;
+}


### PR DESCRIPTION
#### Before

<img width="144" alt="image" src="https://github.com/user-attachments/assets/01ec7748-3b8e-4b00-a6a9-67bd55a8ff75">

#### After

<img width="148" alt="image" src="https://github.com/user-attachments/assets/6d7ada33-257a-4e85-83a8-c6ea03fbf6ba">
