### PR TITLE
refactor: rename colorA to primary, colorB to secondary

### DIFF
--- a/_codux/boards/visual-effects/visual-effects.board.module.scss
+++ b/_codux/boards/visual-effects/visual-effects.board.module.scss
@@ -4,5 +4,5 @@
 }
 
 .contrastColor {
-    color: var(--colorA1);
+    color: var(--primary1);
 }

--- a/_codux/ui-kit/components/components.board.module.scss
+++ b/_codux/ui-kit/components/components.board.module.scss
@@ -88,8 +88,8 @@
     width: 70%;
 }
 .quantityInput {
-    background-color: var(--colorA1);
+    background-color: var(--primary1);
 }
 .quantityInput1 {
-    background-color: var(--colorA1);
+    background-color: var(--primary1);
 }

--- a/app/routes/product-details.$productSlug/route.module.scss
+++ b/app/routes/product-details.$productSlug/route.module.scss
@@ -20,7 +20,7 @@
     margin-top: 8px;
     font: var(--paragraph3);
     line-height: 1;
-    color: var(--colorA4);
+    color: var(--primary4);
 }
 
 .price {

--- a/app/routes/products.$categorySlug/route.module.scss
+++ b/app/routes/products.$categorySlug/route.module.scss
@@ -33,7 +33,7 @@
 }
 
 .categoryLinkActive {
-    color: var(--colorB3);
+    color: var(--secondary3);
 }
 
 .categoryName {

--- a/src/components/cart/cart-item/cart-item.module.scss
+++ b/src/components/cart/cart-item/cart-item.module.scss
@@ -56,7 +56,7 @@
 .root .quantityInput {
     width: 96px;
     height: 32px;
-    border-color: var(--colorA5);
+    border-color: var(--primary5);
 }
 
 .root .quantityInput button {
@@ -64,7 +64,7 @@
 }
 
 .root .quantityInputDisabled {
-    border-color: var(--colorA3);
+    border-color: var(--primary3);
 }
 
 .root.loading {

--- a/src/components/cart/cart.module.scss
+++ b/src/components/cart/cart.module.scss
@@ -10,7 +10,7 @@
     align-items: center;
     justify-content: space-between;
     padding-bottom: 20px;
-    border-bottom: 1px solid var(--colorA5);
+    border-bottom: 1px solid var(--primary5);
 }
 
 .closeButton {
@@ -45,7 +45,7 @@
 .subtotalNote {
     margin: 12px 0;
     font: var(--paragraph3);
-    color: var(--colorA4);
+    color: var(--primary4);
 }
 
 .checkoutButton {

--- a/src/components/drawer/drawer.module.scss
+++ b/src/components/drawer/drawer.module.scss
@@ -11,5 +11,5 @@
     width: 100%;
     max-width: 420px;
     height: 100%;
-    background-color: var(--colorA1);
+    background-color: var(--primary1);
 }

--- a/src/components/footer/footer.module.scss
+++ b/src/components/footer/footer.module.scss
@@ -2,7 +2,7 @@
 
 .root {
     padding: 30px var(--pagePaddingHoriz);
-    background-color: var(--colorA3);
+    background-color: var(--primary3);
 }
 
 .navigation {

--- a/src/components/header/header.module.scss
+++ b/src/components/header/header.module.scss
@@ -75,7 +75,7 @@
     white-space: nowrap;
 
     &:hover {
-        background-color: var(--colorA2);
+        background-color: var(--primary2);
         color: var(--black);
     }
 }

--- a/src/components/order-summary/order-item/order-item.module.scss
+++ b/src/components/order-summary/order-item/order-item.module.scss
@@ -38,7 +38,7 @@ $imageSize: 100px;
 .productDetails {
     margin-top: 12px;
     font: var(--paragraph3);
-    color: var(--colorB3);
+    color: var(--secondary3);
 }
 
 .orderInfo {

--- a/src/components/order-summary/order-summary.module.scss
+++ b/src/components/order-summary/order-summary.module.scss
@@ -7,12 +7,12 @@
 
 .section {
     padding: 40px;
-    border: 1px solid var(--colorA2);
+    border: 1px solid var(--primary2);
 }
 
 .divider {
     height: 1px;
-    background: var(--colorA2);
+    background: var(--primary2);
     border: none;
     margin: 20px 0;
 }
@@ -31,7 +31,7 @@
 
 .note {
     font: var(--paragraph3);
-    color: var(--colorB3);
+    color: var(--secondary3);
 }
 
 .priceSummary {

--- a/src/components/product-card/product-card.module.scss
+++ b/src/components/product-card/product-card.module.scss
@@ -4,7 +4,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--colorA2);
+    background-color: var(--primary2);
 }
 
 .image {
@@ -17,7 +17,7 @@
     width: 60%;
     max-width: 100px;
     min-width: 50px;
-    color: var(--colorA4);
+    color: var(--primary4);
 }
 
 .ribbon {
@@ -26,7 +26,7 @@
     left: 4%;
     padding: 2px 12px;
     border-radius: 40px;
-    background-color: var(--colorA2);
+    background-color: var(--primary2);
     font: var(--paragraph3);
 }
 
@@ -44,7 +44,7 @@
 }
 
 .outOfStock {
-    color: var(--colorA4);
+    color: var(--primary4);
 }
 
 .skeleton > .imageWrapper {

--- a/src/components/quantity-input/quantity-input.module.scss
+++ b/src/components/quantity-input/quantity-input.module.scss
@@ -8,7 +8,7 @@
 }
 
 .root:focus-within {
-    border-color: var(--colorA5);
+    border-color: var(--primary5);
 }
 
 .button {
@@ -21,7 +21,7 @@
 }
 
 .button:disabled {
-    color: var(--colorA3);
+    color: var(--primary3);
     cursor: default;
 }
 
@@ -38,7 +38,7 @@
 }
 
 .input:disabled {
-    color: var(--colorA3);
+    color: var(--primary3);
 }
 
 .input:focus-visible {

--- a/src/components/spinner/spinner.module.scss
+++ b/src/components/spinner/spinner.module.scss
@@ -4,7 +4,7 @@
 
 .circle {
     animation: circleAnimation 1.5s ease-in-out infinite;
-    stroke: var(--colorA5);
+    stroke: var(--primary5);
 }
 
 @keyframes rotation {

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -2,17 +2,17 @@
     --white: #ffffff;
     --black: #000000;
 
-    --colorA1: #fef9ec;
-    --colorA2: #ffefc7;
-    --colorA3: #dad3c1;
-    --colorA4: #767165;
-    --colorA5: #17110d;
+    --primary1: #fef9ec;
+    --primary2: #ffefc7;
+    --primary3: #dad3c1;
+    --primary4: #767165;
+    --primary5: #17110d;
 
-    --colorB1: #ced0c4;
-    --colorB2: #9fa295;
-    --colorB3: #707365;
-    --colorB4: #414434;
-    --colorB5: #22241b;
+    --secondary1: #ced0c4;
+    --secondary2: #9fa295;
+    --secondary3: #707365;
+    --secondary4: #414434;
+    --secondary5: #22241b;
 
     --colorC1: #d1bbd5;
     --colorC2: #a78fac;

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -47,10 +47,10 @@
     align-items: center;
     justify-content: center;
     padding: 12px 16px;
-    border: 1px solid var(--colorA5);
+    border: 1px solid var(--primary5);
     font: var(--paragraph1);
     background-color: transparent;
-    color: var(--colorA5);
+    color: var(--primary5);
     cursor: pointer;
     white-space: nowrap;
     transition: all 200ms ease;
@@ -59,35 +59,35 @@
 
 .button:disabled {
     border-color: transparent;
-    background-color: var(--colorA3);
-    color: var(--colorA1);
+    background-color: var(--primary3);
+    color: var(--primary1);
     cursor: default;
 }
 
 .button:not(:disabled):hover {
-    background-color: var(--colorA5);
-    color: var(--colorA1);
+    background-color: var(--primary5);
+    color: var(--primary1);
 }
 
 .primaryButton {
-    background-color: var(--colorA5);
-    color: var(--colorA1);
+    background-color: var(--primary5);
+    color: var(--primary1);
 }
 
 .primaryButton:not(:disabled):hover {
     background-color: transparent;
-    color: var(--colorA5);
+    color: var(--primary5);
 }
 
 .mutedPrimaryButton {
     border-color: transparent;
-    background-color: var(--colorB3);
-    color: var(--colorA1);
+    background-color: var(--secondary3);
+    color: var(--primary1);
 }
 
 .mutedPrimaryButton:not(:disabled):hover {
     background-color: rgba(112, 115, 101, 0.7);
-    color: var(--colorA1);
+    color: var(--primary1);
 }
 
 /* Icons **********************************************************************/
@@ -146,7 +146,7 @@
     margin-bottom: var(--pagePaddingHoriz);
     height: var(--bannerHeight);
     position: relative;
-    color: var(--colorA1);
+    color: var(--primary1);
     background-color: var(--black);
 }
 
@@ -246,7 +246,7 @@
     z-index: 2;
     padding: 30px;
     text-transform: uppercase;
-    color: var(--colorA1);
+    color: var(--primary1);
     font: var(--heading4);
     text-align: center;
 }
@@ -263,7 +263,7 @@
     width: 32%;
     aspect-ratio: 0.8;
     padding: 22px;
-    background-color: var(--colorA2);
+    background-color: var(--primary2);
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -363,5 +363,5 @@
 /* Miscellaneous **************************************************************/
 
 .alternateBackground {
-    background-color: var(--colorA3);
+    background-color: var(--primary3);
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,6 +1,6 @@
 :root {
     font: var(--paragraph1);
-    color: var(--colorA5);
+    color: var(--primary5);
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -15,7 +15,7 @@ body {
     justify-content: center;
     min-width: 320px;
     min-height: 100vh;
-    background-color: var(--colorA1);
+    background-color: var(--primary1);
 }
 
 :focus-visible {


### PR DESCRIPTION
Mika wants to make it more clear that the scales `colorA` and `colorB` are the most used, and the other color scales are used more sparigly.

Here's how these two scales are named in Wix Studio:
<img width="298" alt="image" src="https://github.com/user-attachments/assets/fe4cd81e-c583-41fa-883e-c44ec73f287c">

The only "action" color used in the template is the third in the scale. Here's what it is used for:
* Browse page: `.categoryLinkActive`
* Order summary: `.note`
* Order item: `.productDetails`
* `.mutedPrimaryButton`

Hardly an "action".

So for lack of better names, I've named them primary (the most used scale), and secondary (the second most used scale).