### PR TITLE
feat: tidy up the components ui kit and add variant wrappers

### DIFF
--- a/_codux/ui-kit/components/components.board.module.scss
+++ b/_codux/ui-kit/components/components.board.module.scss
@@ -1,5 +1,3 @@
-@import '@styles/typography.scss';
-
 .container {
     width: 420px;
     padding: 16px;
@@ -46,50 +44,11 @@
 
 .variantName {
     font-size: 9px;
-    font-weight: 800;
-    line-height: 7px;
-}
-
-.fontDetails {
-    font-size: 9px;
     font-weight: 400;
     line-height: 8px;
     max-width: 244px;
 }
 
-.headlinesSpacing {
-    margin-top: 10px;
-}
-
-.paragraphSpacing {
-    margin-top: 14px;
-    margin-bottom: 30px;
-}
-
-.heading1 {
-    font: var(--heading1);
-    width: 110%;
-}
-
-.heading2 {
-    font: var(--heading2);
-}
-
-.paragraph1 {
-    font: var(--paragraph1);
-}
-
-.paragraph2 {
-    font: var(--paragraph2);
-    font-stretch: expanded;
-}
-
 .accordion {
     width: 70%;
-}
-.quantityInput {
-    background-color: var(--primary1);
-}
-.quantityInput1 {
-    background-color: var(--primary1);
 }

--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -1,5 +1,4 @@
 import { createBoard, Variant } from '@wixc3/react-board';
-import classNames from 'classnames';
 import { Accordion } from '~/components/accordion/accordion';
 import { ProductCard } from '~/components/product-card/product-card';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
@@ -17,46 +16,50 @@ export default createBoard({
                     <span className={styles.foundation}> | Core components</span>
                     <hr className={styles.hrSolid} />
                     <h3 className={styles.sectionTitle}>Components &amp; Elements</h3>
-                    <h4 className={styles.sectionHeader}>INPUT</h4>
                 </div>
-                <QuantityInput value={6} className={styles.quantityInput1} onChange={() => {}} />
-                <span className={styles.fontDetails}>Number Input</span>
-                <Variant name="Heading1">
-                    <hr className={styles.hrLight} />
-                    <h4 className={styles.sectionHeader}>ACCORDION</h4>
-                    <Accordion
-                        items={[
-                            {
-                                title: 'Product Info',
-                                content: 'Content',
-                            },
-                            {
-                                title: 'Return & Refund Policy',
-                                content: 'Content',
-                            },
-                            {
-                                title: 'Shipping Info ',
-                                content: 'Content',
-                            },
-                        ]}
-                        className={styles.accordion}
-                    />
-                    <hr className={styles.hrLight} />
+                <h4 className={styles.sectionHeader}>INPUT</h4>
+                <Variant name="Number Input">
+                    <QuantityInput value={6} onChange={() => {}} />
                 </Variant>
-                <p className={classNames(styles.variantName, styles.headlinesSpacing)}></p>
-                <h4 className={styles.sectionHeader}>LABELS</h4>
-                <h4>Labels missing</h4>
+                <span className={styles.variantName}>Number Input</span>
                 <hr className={styles.hrLight} />
-                <h4 className={styles.sectionHeader}>CARDS</h4>
-                <ProductCard
-                    name="Bamboo Toothbrush"
-                    imageUrl="https://static.wixstatic.com/media/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg/v1/fill/w_824,h_1098,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg"
-                    ribbon="NEW"
-                    price="$5.5"
-                />
-                <span className={styles.fontDetails}>Product Card</span>
-                <h4>Product gallery missing</h4>
-                <span className={styles.fontDetails}>Product Card</span>
+                <h4 className={styles.sectionHeader}>ACCORDION</h4>
+                <div style={{ width: '70%' }}>
+                    <Variant name="Accordion">
+                        <Accordion
+                            items={[
+                                {
+                                    title: 'Product Info',
+                                    content: 'Description',
+                                },
+                                {
+                                    title: 'Return & Refund Policy',
+                                    content: 'Description',
+                                },
+                                {
+                                    title: 'Shipping Info ',
+                                    content: 'Description',
+                                },
+                            ]}
+                        />
+                    </Variant>
+                </div>
+                <hr className={styles.hrLight} />
+                <h4 className={styles.sectionHeader}>LABELS</h4>
+                <Variant name="Ribbon">
+                    <span className="ribbon">Sale</span>
+                </Variant>
+                <hr className={styles.hrLight} />
+                <h4 className={styles.sectionHeader}>PRODUCT CARD</h4>
+                <Variant name="Product Card">
+                    <ProductCard
+                        name="Bamboo Toothbrush"
+                        imageUrl="https://static.wixstatic.com/media/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg/v1/fill/w_824,h_1098,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg"
+                        ribbon="NEW"
+                        price="$6"
+                        discountedPrice="$5.5"
+                    />
+                </Variant>
             </div>
         </ComponentWrapper>
     ),

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -365,3 +365,14 @@
 .alternateBackground {
     background-color: var(--primary3);
 }
+
+.ribbon {
+    display: inline-block;
+    vertical-align: middle;
+    padding: 2px 12px;
+    border-radius: 100px;
+    background-color: var(--primary2);
+    font: var(--paragraph3);
+    text-transform: uppercase;
+    white-space: nowrap;
+}


### PR DESCRIPTION
"Components" UI Kit board:
* Removed unused CSS.
* Wrapped snippets with `<Variant>`.
* Fixed incorrect names for existing variants.
* Removed all board-specific CSS/HTML from variants.
* Added discounted price for the product card.
* Added an example of a "SALE" ribbon.
* Introduced a common class for the ribbon element.

<img width="420" alt="screenshot" src="https://github.com/user-attachments/assets/3a99e88c-3fac-4700-994d-a9f3729b53a9">
