### PR TITLE
fix: make boards as snippets to see them in 'UI Kit' boards group

### DIFF
--- a/_codux/ui-kit/buttons/buttons.board.tsx
+++ b/_codux/ui-kit/buttons/buttons.board.tsx
@@ -137,4 +137,5 @@ export default createBoard({
         windowWidth: 430,
         windowHeight: 700,
     },
+    isSnippet: true,
 });

--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -94,4 +94,5 @@ export default createBoard({
         windowWidth: 400,
         windowHeight: 800,
     },
+    isSnippet: true,
 });

--- a/_codux/ui-kit/sections/sections.board.tsx
+++ b/_codux/ui-kit/sections/sections.board.tsx
@@ -78,4 +78,5 @@ export default createBoard({
         windowWidth: 1070,
         windowHeight: 1800,
     },
+    isSnippet: true,
 });

--- a/_codux/ui-kit/typography/typography.board.tsx
+++ b/_codux/ui-kit/typography/typography.board.tsx
@@ -94,4 +94,5 @@ export default createBoard({
         windowWidth: 450,
         windowHeight: 700,
     },
+    isSnippet: true,
 });


### PR DESCRIPTION
<img width="1423" alt="Screenshot 2024-10-01 at 15 18 23" src="https://github.com/user-attachments/assets/16a5152f-f41d-47df-8064-100e71f36fa0">
