### PR TITLE
feat: allow accordion item content to overflow when expanded

### DIFF
--- a/app/routes/product-details.$productSlug/route.module.scss
+++ b/app/routes/product-details.$productSlug/route.module.scss
@@ -54,6 +54,10 @@
     margin-top: 24px;
 }
 
+.additionalInfoDescription {
+    padding-bottom: 25px;
+}
+
 .socialLinks {
     margin-top: 36px;
 }

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -144,6 +144,7 @@ export default function ProductDetailsPage() {
                                     title: section.title!,
                                     content: section.description ? (
                                         <div
+                                            className={styles.additionalInfoDescription}
                                             dangerouslySetInnerHTML={{
                                                 __html: section.description,
                                             }}

--- a/src/components/accordion/accordion.module.scss
+++ b/src/components/accordion/accordion.module.scss
@@ -21,5 +21,23 @@
 }
 
 .content {
-    padding-bottom: 25px;
+    --transitionDuration: 0.4s;
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows var(--transitionDuration) ease-in-out;
+}
+
+.expanded {
+    grid-template-rows: 1fr;
+}
+
+.contentInner {
+    overflow: auto;
+    transition: overflow 0s allow-discrete;
+}
+
+.expanded .contentInner {
+    // Prevent clipping outline and box-shadow after transition.
+    overflow: visible;
+    transition-delay: var(--transitionDuration);
 }

--- a/src/components/accordion/accordion.module.scss
+++ b/src/components/accordion/accordion.module.scss
@@ -10,12 +10,6 @@
     cursor: pointer;
 }
 
-.header:focus-visible {
-    box-shadow:
-        0 0 0 1px #ffffff,
-        0 0 0 3px #116dff;
-}
-
 .title {
     font: var(--heading5);
     font-size: 18px;
@@ -27,17 +21,5 @@
 }
 
 .content {
-    display: grid;
-    grid-template-rows: 0fr;
-    padding-bottom: 0;
-    transition: all 0.4s ease-in-out;
-}
-
-.contentVisible {
-    grid-template-rows: 1fr;
     padding-bottom: 25px;
-}
-
-.contentInner {
-    overflow-y: auto;
 }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
-import styles from './accordion.module.scss';
-import { MinusIcon, PlusIcon } from '../icons';
-import classNames from 'classnames';
+import { useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { getClickableElementAttributes } from '~/utils';
+import { MinusIcon, PlusIcon } from '../icons';
+
+import styles from './accordion.module.scss';
 
 interface AccordionItem {
     title: string;
@@ -22,32 +23,64 @@ export const Accordion = ({ items, className }: AccordionProps) => {
             {items.map((item, index) => {
                 const isOpen = openItemIndex === index;
                 return (
-                    <div key={index} className={styles.item}>
-                        <div
-                            className={styles.header}
-                            {...getClickableElementAttributes(() =>
-                                setOpenItemIndex(isOpen ? null : index),
-                            )}
-                        >
-                            <p className={styles.title}>{item.title}</p>
-
-                            {isOpen ? (
-                                <MinusIcon className={styles.toggleIcon} />
-                            ) : (
-                                <PlusIcon className={styles.toggleIcon} />
-                            )}
-                        </div>
-
-                        <div
-                            className={classNames(styles.content, {
-                                [styles.contentVisible]: isOpen,
-                            })}
-                        >
-                            <div className={styles.contentInner}>{item.content}</div>
-                        </div>
-                    </div>
+                    <AccordionItem
+                        key={index}
+                        isOpen={isOpen}
+                        onToggle={() => setOpenItemIndex(isOpen ? null : index)}
+                        {...item}
+                    />
                 );
             })}
+        </div>
+    );
+};
+
+interface AccordionItemProps extends AccordionItem {
+    isOpen: boolean;
+    onToggle: () => void;
+}
+
+const AccordionItem = ({ isOpen, onToggle, title, content }: AccordionItemProps) => {
+    const contentRef = useRef<HTMLDivElement | null>(null);
+
+    const isOpenRef = useRef(isOpen);
+    isOpenRef.current = isOpen;
+
+    const handleAnimationComplete = () => {
+        if (contentRef.current && isOpenRef.current) {
+            // Allow the content to overflow when the accordion item is fully expanded.
+            // This is useful when the content contains an element that, under certain conditions,
+            // must go beyond the content (e.g. a box-shadow on focus).
+            contentRef.current.style.removeProperty('overflow');
+        }
+    };
+
+    return (
+        <div className={styles.item}>
+            <div className={styles.header} {...getClickableElementAttributes(onToggle)}>
+                <p className={styles.title}>{title}</p>
+
+                {isOpen ? (
+                    <MinusIcon className={styles.toggleIcon} />
+                ) : (
+                    <PlusIcon className={styles.toggleIcon} />
+                )}
+            </div>
+
+            <AnimatePresence initial={false}>
+                {isOpen && (
+                    <motion.div
+                        ref={contentRef}
+                        initial={{ height: 0, overflow: 'auto' }}
+                        animate={{ height: 'auto', overflow: 'auto' }}
+                        exit={{ height: 0, overflow: 'auto' }}
+                        transition={{ duration: 0.4, ease: 'easeInOut' }}
+                        onAnimationComplete={handleAnimationComplete}
+                    >
+                        <div className={styles.content}>{content}</div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
         </div>
     );
 };

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { useState } from 'react';
+import classNames from 'classnames';
 import { getClickableElementAttributes } from '~/utils';
 import { MinusIcon, PlusIcon } from '../icons';
 
@@ -23,64 +23,32 @@ export const Accordion = ({ items, className }: AccordionProps) => {
             {items.map((item, index) => {
                 const isOpen = openItemIndex === index;
                 return (
-                    <AccordionItem
-                        key={index}
-                        isOpen={isOpen}
-                        onToggle={() => setOpenItemIndex(isOpen ? null : index)}
-                        {...item}
-                    />
+                    <div key={index} className={styles.item}>
+                        <div
+                            className={styles.header}
+                            {...getClickableElementAttributes(() =>
+                                setOpenItemIndex(isOpen ? null : index),
+                            )}
+                        >
+                            <p className={styles.title}>{item.title}</p>
+
+                            {isOpen ? (
+                                <MinusIcon className={styles.toggleIcon} />
+                            ) : (
+                                <PlusIcon className={styles.toggleIcon} />
+                            )}
+                        </div>
+
+                        <div
+                            className={classNames(styles.content, {
+                                [styles.expanded]: isOpen,
+                            })}
+                        >
+                            <div className={styles.contentInner}>{item.content}</div>
+                        </div>
+                    </div>
                 );
             })}
-        </div>
-    );
-};
-
-interface AccordionItemProps extends AccordionItem {
-    isOpen: boolean;
-    onToggle: () => void;
-}
-
-const AccordionItem = ({ isOpen, onToggle, title, content }: AccordionItemProps) => {
-    const contentRef = useRef<HTMLDivElement | null>(null);
-
-    const isOpenRef = useRef(isOpen);
-    isOpenRef.current = isOpen;
-
-    const handleAnimationComplete = () => {
-        if (contentRef.current && isOpenRef.current) {
-            // Allow the content to overflow when the accordion item is fully expanded.
-            // This is useful when the content contains an element that, under certain conditions,
-            // must go beyond the content (e.g. a box-shadow on focus).
-            contentRef.current.style.removeProperty('overflow');
-        }
-    };
-
-    return (
-        <div className={styles.item}>
-            <div className={styles.header} {...getClickableElementAttributes(onToggle)}>
-                <p className={styles.title}>{title}</p>
-
-                {isOpen ? (
-                    <MinusIcon className={styles.toggleIcon} />
-                ) : (
-                    <PlusIcon className={styles.toggleIcon} />
-                )}
-            </div>
-
-            <AnimatePresence initial={false}>
-                {isOpen && (
-                    <motion.div
-                        ref={contentRef}
-                        initial={{ height: 0, overflow: 'auto' }}
-                        animate={{ height: 'auto', overflow: 'auto' }}
-                        exit={{ height: 0, overflow: 'auto' }}
-                        transition={{ duration: 0.4, ease: 'easeInOut' }}
-                        onAnimationComplete={handleAnimationComplete}
-                    >
-                        <div className={styles.content}>{content}</div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
         </div>
     );
 };


### PR DESCRIPTION
I'm using `Accordion` in product filters. A range slider highlights a focused thumb with a box-shadow. Because accordion item has `overflow-y: auto` the overflowed box-shadow is cut off.

<img width="310" alt="Screenshot 2024-10-02 at 18 17 35" src="https://github.com/user-attachments/assets/72ab715c-2f7d-4fa0-9eae-59767ef78b49">
<br /><br />

Using `transition-delay` and `transition-behavior: allow-discrete`  I reset the overflow after transiton ends.