### PR TITLE
Content-fix: changed the variable of "New in" to be --heading3

### DIFF
--- a/src/components/featured-products-section/featured-products-section.module.scss
+++ b/src/components/featured-products-section/featured-products-section.module.scss
@@ -15,7 +15,7 @@
 }
 
 .headerTitle {
-    font: var(--heading1);
+    font: var(--heading3);
     font-size: 3vw;
 }
 

--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -62,7 +62,7 @@ export const FeaturedProductsSection = (props: FeaturedProductsSectionProps) => 
     return (
         <div className={classNames(styles.root, className)}>
             <FadeIn className={styles.header}>
-                <h1 className={styles.headerTitle}>{title ?? data?.category.name}</h1>
+                <h3 className={styles.headerTitle}>{title ?? data?.category.name}</h3>
                 <div className={styles.headerDescription}>
                     {description ?? data?.category.description}
                 </div>


### PR DESCRIPTION
Instead of having two H1 , in different sizes using the same variable (--heading1)
I change the "New in" title to be H3 with the variable of --heading 3.
this didn't affect the design almost at all 
 
<img width="1780" alt="Screenshot 2024-10-08 at 15 02 30" src="https://github.com/user-attachments/assets/ae89bc2a-7ea2-4001-a24f-cb070291e780">
