### PR TITLE
Structure-fix: changed first element of the app home from fragment to div

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -5,7 +5,7 @@ import { BackgroundParallax, FadeIn, FloatIn } from '~/components/visual-effects
 
 export default function HomePage() {
     return (
-        <>
+        <div>
             <div className="heroBanner">
                 <img
                     src="https://static.wixstatic.com/media/32aab9_2c3c65e142434906992aedb17db53566~mv2.jpg"
@@ -93,6 +93,6 @@ export default function HomePage() {
                 title="Best Sellers"
                 description="When quality is eco-friendly. Explore our top picks."
             />
-        </>
+        </div>
     );
 }


### PR DESCRIPTION
the motivation: expose the style panel, and avoid empty state as first experience (this is the first layer selected when opening the app) 
before 
<img width="1780" alt="Screenshot 2024-10-08 at 16 23 29" src="https://github.com/user-attachments/assets/23cb73ab-8aff-4fa0-94b4-a930f3b28385">
after
<img width="1780" alt="Screenshot 2024-10-08 at 16 26 22" src="https://github.com/user-attachments/assets/9e3e2228-7e3c-4fde-8f5c-4e5e7b8375b3">

* if there can be something that will show more styles we should consider it, this is not perfect 