### PR TITLE
feat: set explicit prop values for animation components

### DIFF
--- a/_codux/ui-kit/animations/animations.board.tsx
+++ b/_codux/ui-kit/animations/animations.board.tsx
@@ -13,6 +13,7 @@ export default createBoard({
             <BackgroundParallax
                 className={styles.contrastColor}
                 backgroundImageUrl="https://static.wixstatic.com/media/c837a6_a2f541f9274546a9b4b0a8dbd2cfa3e0~mv2.jpg/v1/fill/w_900,h_600,al_c,q_85,enc_auto/11062b_4ba7b420d917404092175a564fa1358b~mv2-1_edited_edited.jpg"
+                parallaxStrength={0.75}
             >
                 <h4 className="heading4">Parallax</h4>
             </BackgroundParallax>
@@ -32,7 +33,7 @@ export default createBoard({
             <section>
                 <h4 className="heading4">Float In</h4>
                 <Variant name="Animation: Float In">
-                    <FloatIn direction="up" duration={3}>
+                    <FloatIn direction="up" duration={3} distance={120}>
                         <img
                             src="https://static.wixstatic.com/media/c837a6_a2f541f9274546a9b4b0a8dbd2cfa3e0~mv2.jpg/v1/fill/w_900,h_600,al_c,q_85,enc_auto/11062b_4ba7b420d917404092175a564fa1358b~mv2-1_edited_edited.jpg"
                             alt=""

--- a/_codux/ui-kit/sections/sections.board.tsx
+++ b/_codux/ui-kit/sections/sections.board.tsx
@@ -39,8 +39,9 @@ export default createBoard({
                             <BackgroundParallax
                                 className="floatingCardBackground"
                                 backgroundImageUrl="https://static.wixstatic.com/media/c837a6_cae4dbe5a7ee4637b7d55d9bd5bd755d~mv2.png/v1/fill/w_1178,h_974,al_c,q_90,usm_0.66_1.00_0.01,enc_auto/c837a6_cae4dbe5a7ee4637b7d55d9bd5bd755d~mv2.png"
+                                parallaxStrength={0.75}
                             >
-                                <FloatIn direction="up">
+                                <FloatIn direction="up" duration={1.2} distance={120}>
                                     <div className="floatingCard">
                                         <div className="floatingCardHeader">Happy Holidays</div>
                                         <div className="floatingCardContent">

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -22,7 +22,7 @@ export default function HomePage() {
             </div>
 
             <div className="textBannerSection">
-                <FadeIn className="textBanner">
+                <FadeIn className="textBanner" duration={1.8}>
                     <div className="textBannerSubtitle">Products of the highest standards</div>
                     <div className="textBannerTitle">
                         Essential home collections for sustainable living
@@ -70,8 +70,9 @@ export default function HomePage() {
             <BackgroundParallax
                 className="floatingCardBackground"
                 backgroundImageUrl="https://static.wixstatic.com/media/c837a6_cae4dbe5a7ee4637b7d55d9bd5bd755d~mv2.png/v1/fill/w_1178,h_974,al_c,q_90,usm_0.66_1.00_0.01,enc_auto/c837a6_cae4dbe5a7ee4637b7d55d9bd5bd755d~mv2.png"
+                parallaxStrength={0.75}
             >
-                <FloatIn direction="up">
+                <FloatIn direction="up" duration={1.2} distance={120}>
                     <div className="floatingCard">
                         <div className="floatingCardHeader">Happy Holidays</div>
                         <div className="floatingCardContent">

--- a/app/routes/about-us/route.tsx
+++ b/app/routes/about-us/route.tsx
@@ -4,7 +4,7 @@ import styles from './route.module.scss';
 export default function AboutUsPage() {
     return (
         <div className={styles.root}>
-            <Reveal direction="up" duration={3} className={styles.aboutSection}>
+            <Reveal className={styles.aboutSection} direction="up" duration={3}>
                 <h1 className={styles.title}>We are ReClaim</h1>
                 <div className={styles.subtitle}>A women-owned local business</div>
                 <div className={styles.description}>

--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -61,13 +61,13 @@ export const FeaturedProductsSection = (props: FeaturedProductsSectionProps) => 
 
     return (
         <div className={classNames(styles.root, className)}>
-            <FadeIn className={styles.header}>
+            <FadeIn className={styles.header} duration={1.8}>
                 <h3 className={styles.headerTitle}>{title ?? data?.category.name}</h3>
                 <div className={styles.headerDescription}>
                     {description ?? data?.category.description}
                 </div>
             </FadeIn>
-            <Reveal direction="down" className={styles.productsRow}>
+            <Reveal className={styles.productsRow} direction="down" duration={1.4}>
                 {data
                     ? data.products.map((product) => (
                           <ProductLink key={product._id} productSlug={product.slug!}>

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -18,7 +18,7 @@ export const Footer = ({ className }: FooterProps) => {
 
     return (
         <footer className={classNames(styles.root, className)}>
-            <FadeIn className={styles.navigation}>
+            <FadeIn className={styles.navigation} duration={1.8}>
                 <nav>
                     <ul>
                         <li>
@@ -113,7 +113,7 @@ export const Footer = ({ className }: FooterProps) => {
                     </li>
                 </ul>
             </FadeIn>
-            <FadeIn className={styles.bottomBar}>
+            <FadeIn className={styles.bottomBar} duration={1.8}>
                 <Link to={ROUTES.home.to()} className={styles.logo}>
                     ReClaim
                 </Link>


### PR DESCRIPTION
Codux can't correctly detect which props of our animation components are important, and hides them behind "Display all properties (279)". As a workaround, I've passed explicit prop values instead of relying on defaults.

For reference, here are the default values for each animation component:
* `<FadeIn duration={1.8}>`
* `<FloatIn direction="up" duration={1.2} distance={120}>`
* `<Reveal direction="down" duration={1.4}>`
* `<BackgroundParallax parallaxStrength={0.75}>`

Ta-da:

<img width="849" alt="image" src="https://github.com/user-attachments/assets/952ced97-3e10-4a27-a097-2ec16d5ad0b3">