### PR TITLE
fix: price filter fixes

### DIFF
--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -205,6 +205,7 @@ export default function ProductsPage() {
                             onClearFilters={clearFilters}
                             onClearAllFilters={clearAllFilters}
                             currency={currency}
+                            priceBounds={productPriceBounds}
                         />
                     )}
 

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import {
     isRouteErrorResponse,
@@ -93,11 +92,6 @@ export default function ProductsPage() {
         useProductFilters();
 
     const currency = categoryProducts.items[0]?.priceData?.currency ?? 'USD';
-
-    const defaultPriceFilters = useMemo(
-        () => ({ minPrice: productPriceBounds.lowest, maxPrice: productPriceBounds.highest }),
-        [productPriceBounds],
-    );
 
     const renderProducts = () => {
         if (category.numberOfProducts === 0) {
@@ -211,7 +205,8 @@ export default function ProductsPage() {
                             onClearFilters={clearFilters}
                             onClearAllFilters={clearAllFilters}
                             currency={currency}
-                            defaultPriceFilters={defaultPriceFilters}
+                            minPriceInCategory={productPriceBounds.lowest}
+                            maxPriceInCategory={productPriceBounds.highest}
                         />
                     )}
 

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import {
     isRouteErrorResponse,
@@ -92,6 +93,11 @@ export default function ProductsPage() {
         useProductFilters();
 
     const currency = categoryProducts.items[0]?.priceData?.currency ?? 'USD';
+
+    const defaultPriceFilters = useMemo(
+        () => ({ minPrice: productPriceBounds.lowest, maxPrice: productPriceBounds.highest }),
+        [productPriceBounds],
+    );
 
     const renderProducts = () => {
         if (category.numberOfProducts === 0) {
@@ -205,7 +211,7 @@ export default function ProductsPage() {
                             onClearFilters={clearFilters}
                             onClearAllFilters={clearAllFilters}
                             currency={currency}
-                            priceBounds={productPriceBounds}
+                            defaultPriceFilters={defaultPriceFilters}
                         />
                     )}
 

--- a/src/components/applied-product-filters/applied-product-filters.tsx
+++ b/src/components/applied-product-filters/applied-product-filters.tsx
@@ -11,7 +11,10 @@ interface AppliedProductFiltersProps {
     onClearFilters: (filters: ProductFilter[]) => void;
     onClearAllFilters: () => void;
     currency: string;
-    defaultPriceFilters: { minPrice: number; maxPrice: number };
+    // Min and max prices in the current category.
+    // Used to replace missing bounds ("$5 - ?" or "? - $25") when only one filter bound is set.
+    minPriceInCategory: number;
+    maxPriceInCategory: number;
     className?: string;
 }
 
@@ -20,7 +23,8 @@ export const AppliedProductFilters = ({
     onClearFilters,
     onClearAllFilters,
     currency,
-    defaultPriceFilters,
+    minPriceInCategory,
+    maxPriceInCategory,
     className,
 }: AppliedProductFiltersProps) => {
     const { minPrice, maxPrice } = appliedFilters;
@@ -31,12 +35,12 @@ export const AppliedProductFilters = ({
         } else {
             return (
                 <span>
-                    {formatPrice(minPrice ?? defaultPriceFilters.minPrice, currency)}&ndash;
-                    {formatPrice(maxPrice ?? defaultPriceFilters.maxPrice, currency)}
+                    {formatPrice(minPrice ?? minPriceInCategory, currency)}&ndash;
+                    {formatPrice(maxPrice ?? maxPriceInCategory, currency)}
                 </span>
             );
         }
-    }, [minPrice, maxPrice, currency, defaultPriceFilters]);
+    }, [minPrice, maxPrice, currency, minPriceInCategory, maxPriceInCategory]);
 
     return (
         <div className={classNames(styles.root, className)}>

--- a/src/components/applied-product-filters/applied-product-filters.tsx
+++ b/src/components/applied-product-filters/applied-product-filters.tsx
@@ -11,6 +11,7 @@ interface AppliedProductFiltersProps {
     onClearFilters: (filters: ProductFilter[]) => void;
     onClearAllFilters: () => void;
     currency: string;
+    priceBounds: { lowest: number; highest: number };
     className?: string;
 }
 
@@ -19,6 +20,7 @@ export const AppliedProductFilters = ({
     onClearFilters,
     onClearAllFilters,
     currency,
+    priceBounds,
     className,
 }: AppliedProductFiltersProps) => {
     const { minPrice, maxPrice } = appliedFilters;
@@ -26,22 +28,15 @@ export const AppliedProductFilters = ({
     const priceFilter = useMemo<JSX.Element | null>(() => {
         if (minPrice === undefined && maxPrice === undefined) {
             return null;
-        } else if (minPrice !== undefined && maxPrice !== undefined) {
-            return (
-                <span>
-                    {formatPrice(minPrice, currency)}&ndash;{formatPrice(maxPrice, currency)}
-                </span>
-            );
         } else {
             return (
                 <span>
-                    {minPrice !== undefined
-                        ? formatPrice(minPrice, currency)
-                        : formatPrice(maxPrice!, currency)}
+                    {formatPrice(minPrice ?? priceBounds.lowest, currency)}&ndash;
+                    {formatPrice(maxPrice ?? priceBounds.highest, currency)}
                 </span>
             );
         }
-    }, [minPrice, maxPrice, currency]);
+    }, [minPrice, maxPrice, currency, priceBounds]);
 
     return (
         <div className={classNames(styles.root, className)}>

--- a/src/components/applied-product-filters/applied-product-filters.tsx
+++ b/src/components/applied-product-filters/applied-product-filters.tsx
@@ -11,7 +11,7 @@ interface AppliedProductFiltersProps {
     onClearFilters: (filters: ProductFilter[]) => void;
     onClearAllFilters: () => void;
     currency: string;
-    priceBounds: { lowest: number; highest: number };
+    defaultPriceFilters: { minPrice: number; maxPrice: number };
     className?: string;
 }
 
@@ -20,7 +20,7 @@ export const AppliedProductFilters = ({
     onClearFilters,
     onClearAllFilters,
     currency,
-    priceBounds,
+    defaultPriceFilters,
     className,
 }: AppliedProductFiltersProps) => {
     const { minPrice, maxPrice } = appliedFilters;
@@ -31,12 +31,12 @@ export const AppliedProductFilters = ({
         } else {
             return (
                 <span>
-                    {formatPrice(minPrice ?? priceBounds.lowest, currency)}&ndash;
-                    {formatPrice(maxPrice ?? priceBounds.highest, currency)}
+                    {formatPrice(minPrice ?? defaultPriceFilters.minPrice, currency)}&ndash;
+                    {formatPrice(maxPrice ?? defaultPriceFilters.maxPrice, currency)}
                 </span>
             );
         }
-    }, [minPrice, maxPrice, currency, priceBounds]);
+    }, [minPrice, maxPrice, currency, defaultPriceFilters]);
 
     return (
         <div className={classNames(styles.root, className)}>

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -53,13 +53,18 @@ export const ProductFilters = ({
                     content: (
                         <RangeSlider
                             className="rangeSlider"
+                            step="any"
                             startValue={filters.minPrice ?? lowestPrice}
                             endValue={filters.maxPrice ?? highestPrice}
                             onStartValueChange={(value) => {
-                                handleFiltersChange({ minPrice: value });
+                                handleFiltersChange({
+                                    minPrice: value === lowestPrice ? value : Math.round(value),
+                                });
                             }}
                             onEndValueChange={(value) => {
-                                handleFiltersChange({ maxPrice: value });
+                                handleFiltersChange({
+                                    maxPrice: value === highestPrice ? value : Math.round(value),
+                                });
                             }}
                             minValue={lowestPrice}
                             maxValue={highestPrice}

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -58,12 +58,12 @@ export const ProductFilters = ({
                             endValue={filters.maxPrice ?? highestPrice}
                             onStartValueChange={(value) => {
                                 handleFiltersChange({
-                                    minPrice: value === lowestPrice ? value : Math.round(value),
+                                    minPrice: Math.max(Math.floor(value), lowestPrice),
                                 });
                             }}
                             onEndValueChange={(value) => {
                                 handleFiltersChange({
-                                    maxPrice: value === highestPrice ? value : Math.round(value),
+                                    maxPrice: Math.min(Math.ceil(value), highestPrice),
                                 });
                             }}
                             minValue={lowestPrice}

--- a/src/components/range-slider/range-slider.tsx
+++ b/src/components/range-slider/range-slider.tsx
@@ -17,7 +17,7 @@ interface RangeSlider {
     /**
      * The granularity that the values must adhere to. @default 1
      */
-    step?: number;
+    step?: number | 'any';
     /**
      * Allows to format the displayed start and end values. For example, add a currency symbol,
      * format with the specified number of decimal places, etc.


### PR DESCRIPTION
1. When `min` or `max ` of `<input type="range" />` is a floating number and the step is an integer, the slider looks weird:
<img width="230" alt="Screenshot 2024-10-09 at 12 46 24" src="https://github.com/user-attachments/assets/26cedeb5-499b-429b-a533-03808c62c5f3">

Plain HTML https://jsfiddle.net/v6xpecL0/

To overcome this I set `step="any"` to the price range slider.
Additionally, I round values on change, because:
1. It's not convinient to slide between decimals.
2. It's nicer to have integer in URL than `?maxPrice=11.1199717420213`
<hr />

2. Previously, applied price filter looked bad after changing only mimumum or only maximum:

<img width="1094" alt="Screenshot 2024-10-09 at 12 53 09" src="https://github.com/user-attachments/assets/16f40837-6539-4205-877b-9005c5281209">
<br /><br />

The fix is to show the lowest/highest value if it's not applied explicitly.

<img width="1094" alt="Screenshot 2024-10-09 at 12 56 24" src="https://github.com/user-attachments/assets/a587101a-e96a-4631-9319-e58e01bbb467">


