### PR TITLE
refactor: move cart logic in one place

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -9,6 +9,7 @@ import {
 import { products } from '@wix/stores';
 import classNames from 'classnames';
 import { useState } from 'react';
+import { useCart } from '~/api/use-cart';
 import { getEcomApi } from '~/api/ecom-api';
 import { EcomApiErrorCodes } from '~/api/types';
 import { Accordion } from '~/components/accordion/accordion';
@@ -23,7 +24,6 @@ import { ROUTES } from '~/router/config';
 import { BreadcrumbData, RouteHandle } from '~/router/types';
 import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
 import { useBreadcrumbs } from '~/router/use-breadcrumbs';
-import { useCart } from '~/api/use-cart';
 
 import styles from './route.module.scss';
 

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -76,10 +76,10 @@ export const handle: RouteHandle<typeof loader, ProductDetailsLocationState> = {
 export default function ProductDetailsPage() {
     const { product, canonicalUrl } = useLoaderData<typeof loader>();
     const breadcrumbs = useBreadcrumbs();
-    const { triggerAddToCart, isAddingToCart } = useCart();
+    const { addToCart, isAddingToCart } = useCart();
 
     const handleAddToCartClick = () => {
-        triggerAddToCart(
+        addToCart(
             {
                 id: product._id!,
                 quantity,

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -76,7 +76,11 @@ export const handle: RouteHandle<typeof loader, ProductDetailsLocationState> = {
 export default function ProductDetailsPage() {
     const { product, canonicalUrl } = useLoaderData<typeof loader>();
     const breadcrumbs = useBreadcrumbs();
+
+    const cartOpener = useCartOpen();
     const { addToCart, isAddingToCart } = useCart();
+
+    const [quantity, setQuantity] = useState(1);
 
     const handleAddToCartClick = () => {
         addToCart(
@@ -85,16 +89,10 @@ export default function ProductDetailsPage() {
                 quantity,
             },
             {
-                onSuccess: () => {
-                    cartOpener.setIsOpen(true);
-                },
+                onSuccess: () => cartOpener.setIsOpen(true),
             },
         );
     };
-
-    const cartOpener = useCartOpen();
-
-    const [quantity, setQuantity] = useState(1);
 
     const isOutOfStock = product.stock?.inventoryStatus === products.InventoryStatus.OUT_OF_STOCK;
 

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -9,7 +9,6 @@ import {
 import { products } from '@wix/stores';
 import classNames from 'classnames';
 import { useState } from 'react';
-import { useAddToCart } from '~/api/api-hooks';
 import { getEcomApi } from '~/api/ecom-api';
 import { EcomApiErrorCodes } from '~/api/types';
 import { Accordion } from '~/components/accordion/accordion';
@@ -24,6 +23,8 @@ import { ROUTES } from '~/router/config';
 import { BreadcrumbData, RouteHandle } from '~/router/types';
 import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
 import { useBreadcrumbs } from '~/router/use-breadcrumbs';
+import { useCart } from '~/api/use-cart';
+
 import styles from './route.module.scss';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
@@ -75,23 +76,25 @@ export const handle: RouteHandle<typeof loader, ProductDetailsLocationState> = {
 export default function ProductDetailsPage() {
     const { product, canonicalUrl } = useLoaderData<typeof loader>();
     const breadcrumbs = useBreadcrumbs();
-
-    const cartOpener = useCartOpen();
-    const { trigger: addToCart, isMutating: isAddingToCart } = useAddToCart();
-
-    const [quantity, setQuantity] = useState(1);
+    const { triggerAddToCart, isAddingToCart } = useCart();
 
     const handleAddToCartClick = () => {
-        addToCart(
+        triggerAddToCart(
             {
                 id: product._id!,
                 quantity,
             },
             {
-                onSuccess: () => cartOpener.setIsOpen(true),
+                onSuccess: () => {
+                    cartOpener.setIsOpen(true);
+                },
             },
         );
     };
+
+    const cartOpener = useCartOpen();
+
+    const [quantity, setQuantity] = useState(1);
 
     const isOutOfStock = product.stock?.inventoryStatus === products.InventoryStatus.OUT_OF_STOCK;
 

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -83,7 +83,7 @@ export const useAddToCart = () => {
             if (addToCartResponse.status === 'failure') {
                 throw addToCartResponse.error;
             }
-            return addToCartResponse.body;
+            return arg.id;
         },
         {
             revalidate: false,
@@ -101,7 +101,7 @@ export const useUpdateCartItemQuantity = () => {
             if (response.status === 'failure') {
                 throw response.error;
             }
-            return response.body;
+            return arg.id;
         },
         {
             revalidate: false,
@@ -119,7 +119,7 @@ export const useRemoveItemFromCart = () => {
             if (response.status === 'failure') {
                 throw response.error;
             }
-            return response.body;
+            return arg;
         },
         {
             revalidate: false,

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import useSwr, { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { findItemIdInCart } from './cart-helpers';

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -83,7 +83,7 @@ export const useAddToCart = () => {
             if (addToCartResponse.status === 'failure') {
                 throw addToCartResponse.error;
             }
-            return arg.id;
+            return addToCartResponse.body;
         },
         {
             revalidate: false,
@@ -101,7 +101,7 @@ export const useUpdateCartItemQuantity = () => {
             if (response.status === 'failure') {
                 throw response.error;
             }
-            return arg.id;
+            return response.body;
         },
         {
             revalidate: false,
@@ -119,7 +119,7 @@ export const useRemoveItemFromCart = () => {
             if (response.status === 'failure') {
                 throw response.error;
             }
-            return arg;
+            return response.body;
         },
         {
             revalidate: false,

--- a/src/api/cart-helpers.ts
+++ b/src/api/cart-helpers.ts
@@ -1,4 +1,5 @@
-import ecom from '@wix/ecom';
+import ecom, { cart } from '@wix/ecom';
+import { CartTotals } from './types';
 
 export function findItemIdInCart(
     cart: ecom.cart.Cart & ecom.cart.CartNonNullableFields,
@@ -30,3 +31,9 @@ export function findItemIdInCart(
 export function calculateCartItemsCount(cart: ecom.cart.Cart): number {
     return cart.lineItems?.reduce((total, item) => total + item.quantity!, 0) ?? 0;
 }
+
+export const getCartItemSubtotal = (item: cart.LineItem, cartTotals: CartTotals) => {
+    return cartTotals.calculatedLineItems.find(
+        (calculatedItem) => calculatedItem.lineItemId === item._id,
+    )?.pricesBreakdown?.lineItemPrice;
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -110,3 +110,25 @@ export type EcomAPI = {
         categorySlug: string,
     ) => Promise<EcomAPIResponse<{ lowest: number; highest: number }>>;
 };
+
+export type Image = {
+    id: string;
+    url: string;
+    height: number;
+    width: number;
+    altText?: string;
+    filename?: string;
+};
+
+export interface CartItem {
+    id: string;
+    quantity?: number;
+    price?: cart.MultiCurrencyPrice;
+    subtotal?: cart.MultiCurrencyPrice;
+    productName: string;
+    image?: Image;
+    isUpdating: boolean;
+    isUnavailable: boolean;
+    onRemove: () => void;
+    onQuantityChange: (quantity: number) => void;
+}

--- a/src/api/use-cart-item.ts
+++ b/src/api/use-cart-item.ts
@@ -1,14 +1,16 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { CartItem } from './types';
 import debounce from 'lodash.debounce';
 
 export const useCartItem = (item: CartItem) => {
     const [quantity, setQuantity] = useState(item.quantity!);
 
+    const updateItemQuantityDebounced = useMemo(() => debounce(item.onQuantityChange, 300), [item]);
+
     const onQuantityChange = (value: number) => {
         setQuantity(value);
         if (value > 0) {
-            debounce(() => item.onQuantityChange(value), 300);
+            updateItemQuantityDebounced(value);
         }
     };
 

--- a/src/api/use-cart-item.ts
+++ b/src/api/use-cart-item.ts
@@ -5,12 +5,11 @@ import debounce from 'lodash.debounce';
 export const useCartItem = (item: CartItem) => {
     const [quantity, setQuantity] = useState(item.quantity!);
 
-    const updateItemQuantityDebounced = useMemo(() => debounce(item.onQuantityChange, 300), [item]);
-
     useEffect(() => {
         setQuantity(item.quantity!);
     }, [item.quantity]);
 
+    const updateItemQuantityDebounced = useMemo(() => debounce(item.onQuantityChange, 300), [item]);
     const onQuantityChange = (value: number) => {
         setQuantity(value);
         if (value > 0) {

--- a/src/api/use-cart-item.ts
+++ b/src/api/use-cart-item.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CartItem } from './types';
 import debounce from 'lodash.debounce';
 
@@ -6,6 +6,10 @@ export const useCartItem = (item: CartItem) => {
     const [quantity, setQuantity] = useState(item.quantity!);
 
     const updateItemQuantityDebounced = useMemo(() => debounce(item.onQuantityChange, 300), [item]);
+
+    useEffect(() => {
+        setQuantity(item.quantity!);
+    }, [item.quantity]);
 
     const onQuantityChange = (value: number) => {
         setQuantity(value);

--- a/src/api/use-cart-item.ts
+++ b/src/api/use-cart-item.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+import { CartItem } from './types';
+import debounce from 'lodash.debounce';
+
+export const useCartItem = (item: CartItem) => {
+    const [quantity, setQuantity] = useState(item.quantity!);
+
+    const onQuantityChange = (value: number) => {
+        setQuantity(value);
+        if (value > 0) {
+            debounce(() => item.onQuantityChange(value), 300);
+        }
+    };
+
+    return {
+        quantity,
+        onQuantityChange,
+    };
+};

--- a/src/api/use-cart.ts
+++ b/src/api/use-cart.ts
@@ -25,13 +25,21 @@ export interface UseCartResult {
 
 export const useCart = (): UseCartResult => {
     const ecomAPI = useEcomAPI();
-    const { data, isMutating: isCartMutating, trigger: triggerCartUpdate } = useCartAndTotals();
-    const cart = data?.cart;
-    const cartTotals = data?.totals;
+    const {
+        data: cartData,
+        isMutating: isCartMutating,
+        trigger: triggerCartUpdate,
+    } = useCartAndTotals();
+    const cart = cartData?.cart;
+    const cartTotals = cartData?.totals;
 
     const [cartItems, setCartItems] = useState<CartItem[]>([]);
 
-    const { trigger: triggerAddToCart, data: cartItemAdded, isMutating: isAddingToCart } = useAddToCart();
+    const {
+        trigger: triggerAddToCart,
+        data: cartItemAdded,
+        isMutating: isAddingToCart,
+    } = useAddToCart();
 
     const {
         trigger: removeItem,
@@ -53,11 +61,11 @@ export const useCart = (): UseCartResult => {
     }, [quantityUpdated, cartItemRemoved, cartItemAdded]);
 
     useEffect(() => {
-        if (data) {
+        if (cartData) {
             setCartItems(computeCartItems());
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data]);
+    }, [cartData]);
 
     const computeCartItems = () => {
         return (

--- a/src/api/use-cart.ts
+++ b/src/api/use-cart.ts
@@ -77,7 +77,7 @@ export const useCart = (): UseCartResult => {
                     price: item.price,
                     subtotal: cartTotals ? getCartItemSubtotal(item, cartTotals) : undefined,
                     image: item.image ? media.getImageUrl(item.image) : undefined,
-                    isUpdating: isRemovingItem || isUpdatingItemQuantity,
+                    isUpdating: false, // here remember item who is waiting for the cart update
                     isUnavailable:
                         item.availability?.status === cartType.ItemAvailabilityStatus.NOT_AVAILABLE,
                     onRemove: () => removeItem(item._id!),

--- a/src/api/use-cart.ts
+++ b/src/api/use-cart.ts
@@ -37,28 +37,28 @@ export const useCart = (): UseCartResult => {
 
     const {
         trigger: triggerAddToCart,
-        data: cartItemAdded,
+        data: cartAfterItemAdded,
         isMutating: isAddingToCart,
     } = useAddToCart();
 
     const {
         trigger: removeItem,
-        data: cartItemRemoved,
+        data: cartAfterItemRemoved,
         isMutating: isRemovingItem,
     } = useRemoveItemFromCart();
 
     const {
         trigger: updateItemQuantity,
-        data: quantityUpdated,
+        data: cartAfterQuantityUpdated,
         isMutating: isUpdatingItemQuantity,
     } = useUpdateCartItemQuantity();
 
     useEffect(() => {
-        if (cartItemRemoved || quantityUpdated || cartItemAdded) {
+        if (cartAfterItemRemoved || cartAfterQuantityUpdated || cartAfterItemAdded) {
             triggerCartUpdate();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [quantityUpdated, cartItemRemoved, cartItemAdded]);
+    }, [cartAfterQuantityUpdated, cartAfterItemRemoved, cartAfterItemAdded]);
 
     useEffect(() => {
         if (cartData) {

--- a/src/api/use-cart.ts
+++ b/src/api/use-cart.ts
@@ -1,0 +1,102 @@
+import type { CartItem } from './types';
+import { useEcomAPI } from './ecom-api-context-provider';
+import { cart as cartType } from '@wix/ecom';
+import { getCartItemSubtotal } from './cart-helpers';
+import {
+    useAddToCart,
+    useCartAndTotals,
+    useRemoveItemFromCart,
+    useUpdateCartItemQuantity,
+} from './api-hooks';
+import { useEffect, useState } from 'react';
+import { media } from '@wix/sdk';
+
+export interface UseCartResult {
+    cartItems: CartItem[];
+    priceSummary?: cartType.PriceSummary;
+
+    isCartMutating: boolean;
+    isAddingToCart: boolean;
+
+    triggerCartUpdate: () => void;
+    triggerAddToCart: (args1: any, args2: any) => void; //  any temporarily
+    handleCheckout: () => void;
+}
+
+export const useCart = (): UseCartResult => {
+    const ecomAPI = useEcomAPI();
+    const { data, isMutating: isCartMutating, trigger: triggerCartUpdate } = useCartAndTotals();
+    const cart = data?.cart;
+    const cartTotals = data?.totals;
+
+    const [cartItems, setCartItems] = useState<CartItem[]>([]);
+
+    const { trigger: triggerAddToCart, data: cartItemAdded, isMutating: isAddingToCart } = useAddToCart();
+
+    const {
+        trigger: removeItem,
+        data: cartItemRemoved,
+        isMutating: isRemovingItem,
+    } = useRemoveItemFromCart();
+
+    const {
+        trigger: updateItemQuantity,
+        data: quantityUpdated,
+        isMutating: isUpdatingItemQuantity,
+    } = useUpdateCartItemQuantity();
+
+    useEffect(() => {
+        if (cartItemRemoved || quantityUpdated || cartItemAdded) {
+            triggerCartUpdate();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [quantityUpdated, cartItemRemoved, cartItemAdded]);
+
+    useEffect(() => {
+        if (data) {
+            setCartItems(computeCartItems());
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    const computeCartItems = () => {
+        return (
+            cart?.lineItems.map((item) => {
+                return {
+                    id: item._id!,
+                    productName: item.productName?.translated ?? '',
+                    quantity: item.quantity,
+                    price: item.price,
+                    subtotal: cartTotals ? getCartItemSubtotal(item, cartTotals) : undefined,
+                    image: item.image ? media.getImageUrl(item.image) : undefined,
+                    isUpdating: isRemovingItem || isUpdatingItemQuantity,
+                    isUnavailable:
+                        item.availability?.status === cartType.ItemAvailabilityStatus.NOT_AVAILABLE,
+                    onRemove: () => removeItem(item._id!),
+                    onQuantityChange: (quantity: number) =>
+                        updateItemQuantity({ id: item._id!, quantity }),
+                };
+            }) ?? []
+        );
+    };
+
+    const handleCheckout = async () => {
+        const checkoutResponse = await ecomAPI.checkout();
+
+        if (checkoutResponse.status === 'success') {
+            window.location.href = checkoutResponse.body.checkoutUrl;
+        } else {
+            alert('Checkout failed.');
+        }
+    };
+
+    return {
+        cartItems,
+        priceSummary: cartTotals?.priceSummary,
+        isCartMutating,
+        isAddingToCart,
+        triggerCartUpdate,
+        triggerAddToCart,
+        handleCheckout,
+    };
+};

--- a/src/components/cart/cart-item/cart-item.tsx
+++ b/src/components/cart/cart-item/cart-item.tsx
@@ -1,11 +1,11 @@
+import { CartItem as CartItemType } from '~/api/types';
+import { useCartItem } from '~/api/use-cart-item';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { TrashIcon, ImagePlaceholderIcon, ErrorIcon } from '~/components/icons';
 import { Spinner } from '~/components/spinner/spinner';
 import classNames from 'classnames';
-import { CartItem as CartItemType } from '~/api/types';
 
 import styles from './cart-item.module.scss';
-import { useCartItem } from '~/api/use-cart-item';
 
 export interface CartItemProps {
     item: CartItemType;
@@ -13,7 +13,7 @@ export interface CartItemProps {
 
 export const CartItem = ({ item }: CartItemProps) => {
     const { quantity, onQuantityChange } = useCartItem(item);
-    
+
     return (
         <div className={classNames(styles.root, { [styles.loading]: item.isUpdating })}>
             <div className={styles.itemContent}>

--- a/src/components/cart/cart-item/cart-item.tsx
+++ b/src/components/cart/cart-item/cart-item.tsx
@@ -13,7 +13,7 @@ export interface CartItemProps {
 
 export const CartItem = ({ item }: CartItemProps) => {
     const { quantity, onQuantityChange } = useCartItem(item);
-
+    
     return (
         <div className={classNames(styles.root, { [styles.loading]: item.isUpdating })}>
             <div className={styles.itemContent}>

--- a/src/components/cart/cart.tsx
+++ b/src/components/cart/cart.tsx
@@ -1,45 +1,22 @@
-import { cart } from '@wix/ecom';
 import classNames from 'classnames';
-import { useCart, useCartTotals } from '~/api/api-hooks';
-import { calculateCartItemsCount } from '~/api/cart-helpers';
-import { useEcomAPI } from '~/api/ecom-api-context-provider';
 import { Drawer } from '~/components/drawer/drawer';
 import { CloseIcon, LockIcon } from '~/components/icons';
 import { CartItem } from './cart-item/cart-item';
 import { useCartOpen } from './cart-open-context';
+import { useCart } from '~/api/use-cart';
 
 import styles from './cart.module.scss';
 
 export const Cart = () => {
-    const ecomAPI = useEcomAPI();
     const cartOpener = useCartOpen();
-    const cart = useCart();
-    const cartTotals = useCartTotals();
-
-    const handleCheckout = async () => {
-        const checkoutResponse = await ecomAPI.checkout();
-
-        if (checkoutResponse.status === 'success') {
-            window.location.href = checkoutResponse.body.checkoutUrl;
-        } else {
-            alert('Checkout failed.');
-        }
-    };
-
-    const findLineItemPriceBreakdown = (item: cart.LineItem) => {
-        return cartTotals.data?.calculatedLineItems.find(
-            (calculatedItem) => calculatedItem.lineItemId === item._id,
-        )?.pricesBreakdown;
-    };
-
-    const itemsCount = cart.data ? calculateCartItemsCount(cart.data) : 0;
+    const { cartItems, priceSummary, handleCheckout } = useCart();
 
     return (
         <Drawer open={cartOpener.isOpen} onClose={() => cartOpener.setIsOpen(false)}>
             <div className={styles.cart}>
                 <div className={styles.header}>
                     <span className="heading6">
-                        Cart ({itemsCount} {itemsCount === 1 ? 'item' : 'items'})
+                        Cart ({cartItems.length} {cartItems.length === 1 ? 'item' : 'items'})
                     </span>
 
                     <button
@@ -50,30 +27,24 @@ export const Cart = () => {
                     </button>
                 </div>
 
-                {cart.data && cart.data.lineItems.length > 0 ? (
+                {cartItems.length > 0 ? (
                     <>
                         <div className={styles.cartItems}>
-                            {cart.data.lineItems.map((item) => (
-                                <CartItem
-                                    key={item._id}
-                                    item={item}
-                                    priceBreakdown={findLineItemPriceBreakdown(item)}
-                                />
+                            {cartItems.map((item) => (
+                                <CartItem key={item.id} item={item} />
                             ))}
                         </div>
 
                         <div className={styles.footer}>
-                            {cart.data.subtotal && (
-                                <>
-                                    <div className={styles.subtotal}>
-                                        <span>Subtotal</span>
-                                        <span>{cart.data.subtotal.formattedConvertedAmount}</span>
-                                    </div>
-                                    <div className={styles.subtotalNote}>
-                                        Taxes and shipping are calculated at checkout.
-                                    </div>
-                                </>
-                            )}
+                            <>
+                                <div className={styles.subtotal}>
+                                    <span>Subtotal</span>
+                                    <span>{priceSummary?.subtotal?.formattedConvertedAmount}</span>
+                                </div>
+                                <div className={styles.subtotalNote}>
+                                    Taxes and shipping are calculated at checkout.
+                                </div>
+                            </>
 
                             <button
                                 className={classNames(

--- a/src/components/cart/cart.tsx
+++ b/src/components/cart/cart.tsx
@@ -9,7 +9,7 @@ import styles from './cart.module.scss';
 
 export const Cart = () => {
     const cartOpener = useCartOpen();
-    const { cartItems, priceSummary, handleCheckout } = useCart();
+    const { cartTotals, cartItems, handleCheckout } = useCart();
 
     return (
         <Drawer open={cartOpener.isOpen} onClose={() => cartOpener.setIsOpen(false)}>
@@ -39,7 +39,12 @@ export const Cart = () => {
                             <>
                                 <div className={styles.subtotal}>
                                     <span>Subtotal</span>
-                                    <span>{priceSummary?.subtotal?.formattedConvertedAmount}</span>
+                                    <span>
+                                        {
+                                            cartTotals?.priceSummary?.subtotal
+                                                ?.formattedConvertedAmount
+                                        }
+                                    </span>
                                 </div>
                                 <div className={styles.subtotalNote}>
                                     Taxes and shipping are calculated at checkout.


### PR DESCRIPTION
To be possible to unify cart logic between similar projects, the cart logic moved to one hook `useCart`.

No Cart page in this PR, only Cart in the right panel.

If you have questions how cart gets data, see the image below.

**Cart caching and API flow diagram:**
<img width="1473" alt="Screenshot 2024-10-11 at 11 53 59" src="https://github.com/user-attachments/assets/f96319e4-9360-4489-93a1-06d5d9486cc1">


[Excalidraw](https://excalidraw.com/#json=dSn4DmAdewjHDgfqdf8ow,WCDfoJG244SSy_slVeQH3g)

