### PR TITLE
feat: color select

### DIFF
--- a/_codux/boards/color-select.board.tsx
+++ b/_codux/boards/color-select.board.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { createBoard } from '@wixc3/react-board';
+import { ColorSelect, ColorSelectOption } from '~/components/color-select/color-select';
+
+const options: ColorSelectOption[] = [
+    { id: 'color1', color: '#00a400' },
+    { id: 'color2', color: 'rgb(214, 122, 127)' },
+    { id: 'color3', color: 'hsl(30deg 82% 43%)' },
+    { id: 'color4', color: 'rebeccapurple' },
+];
+
+export default createBoard({
+    name: 'Color Select',
+    Board: () => {
+        const [color, setColor] = useState('');
+        return <ColorSelect options={options} selectedId={color} onChange={setColor} />;
+    },
+    environmentProps: {
+        windowWidth: 400,
+        windowHeight: 100,
+    },
+});

--- a/_codux/boards/color-select.board.tsx
+++ b/_codux/boards/color-select.board.tsx
@@ -12,8 +12,8 @@ const options: ColorSelectOption[] = [
 export default createBoard({
     name: 'Color Select',
     Board: () => {
-        const [color, setColor] = useState('');
-        return <ColorSelect options={options} selectedId={color} onChange={setColor} />;
+        const [colorId, setColorId] = useState('');
+        return <ColorSelect options={options} selectedId={colorId} onChange={setColorId} />;
     },
     environmentProps: {
         windowWidth: 400,

--- a/_codux/boards/color-select.board.tsx
+++ b/_codux/boards/color-select.board.tsx
@@ -3,17 +3,27 @@ import { createBoard } from '@wixc3/react-board';
 import { ColorSelect, ColorSelectOption } from '~/components/color-select/color-select';
 
 const options: ColorSelectOption[] = [
-    { id: 'color1', color: '#00a400' },
-    { id: 'color2', color: 'rgb(214, 122, 127)' },
-    { id: 'color3', color: 'hsl(30deg 82% 43%)' },
-    { id: 'color4', color: 'rebeccapurple' },
+    { id: 'color1', color: 'white' },
+    { id: 'color2', color: 'black' },
+    { id: 'color3', color: '#00a400' },
+    { id: 'color4', color: 'rgb(214, 122, 127)' },
+    { id: 'color5', color: 'hsl(30deg 82% 43%)' },
 ];
 
 export default createBoard({
     name: 'Color Select',
     Board: () => {
         const [colorId, setColorId] = useState('');
-        return <ColorSelect options={options} selectedId={colorId} onChange={setColorId} />;
+        return (
+            <div style={{ padding: '24px' }}>
+                <ColorSelect
+                    className="colorSelect"
+                    options={options}
+                    selectedId={colorId}
+                    onChange={setColorId}
+                />
+            </div>
+        );
     },
     environmentProps: {
         windowWidth: 400,

--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -5,6 +5,7 @@ import { QuantityInput } from '~/components/quantity-input/quantity-input';
 import { Select, SelectItem } from '~/components/select/select';
 import classNames from 'classnames';
 import { CategoryLink } from '~/components/category-link/category-link';
+import { ColorSelect } from '~/components/color-select/color-select';
 import ComponentWrapper from '_codux/board-wrappers/component-wrapper';
 import { Kit } from '../ui-kit-utils/kit';
 
@@ -22,7 +23,9 @@ export default createBoard({
                         </Variant>
                         <Kit.Description>Number Input</Kit.Description>
                     </Kit.Item>
+                </Kit.Section>
 
+                <Kit.Section title="Selects">
                     <Kit.Item>
                         <Variant name="Select">
                             <Select value="" onValueChange={() => {}} placeholder="Select value">
@@ -32,6 +35,22 @@ export default createBoard({
                             </Select>
                         </Variant>
                         <Kit.Description>Select</Kit.Description>
+                    </Kit.Item>
+
+                    <Kit.Item>
+                        <Variant name="Color Select">
+                            <ColorSelect
+                                selectedId="color2"
+                                onChange={() => {}}
+                                options={[
+                                    { id: 'color1', color: '#00a400' },
+                                    { id: 'color2', color: 'rgb(214, 122, 127)' },
+                                    { id: 'color3', color: 'hsl(30deg 82% 43%)' },
+                                    { id: 'color4', color: 'rebeccapurple' },
+                                ]}
+                            />
+                        </Variant>
+                        <Kit.Description>Color Select</Kit.Description>
                     </Kit.Item>
                 </Kit.Section>
 

--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -40,13 +40,15 @@ export default createBoard({
                     <Kit.Item>
                         <Variant name="Color Select">
                             <ColorSelect
+                                className="colorSelect"
                                 selectedId="color2"
                                 onChange={() => {}}
                                 options={[
-                                    { id: 'color1', color: '#00a400' },
-                                    { id: 'color2', color: 'rgb(214, 122, 127)' },
-                                    { id: 'color3', color: 'hsl(30deg 82% 43%)' },
-                                    { id: 'color4', color: 'rebeccapurple' },
+                                    { id: 'color1', color: 'white' },
+                                    { id: 'color2', color: 'black' },
+                                    { id: 'color3', color: '#00a400' },
+                                    { id: 'color4', color: 'rgb(214, 122, 127)' },
+                                    { id: 'color5', color: 'hsl(30deg 82% 43%)' },
                                 ]}
                             />
                         </Variant>

--- a/src/components/color-select/color-select.module.scss
+++ b/src/components/color-select/color-select.module.scss
@@ -1,0 +1,41 @@
+.root {
+    display: flex;
+    gap: 8px;
+}
+
+.option {
+    height: 20px;
+    width: 20px;
+    border: 1px solid var(--primary3);
+    border-radius: 50%;
+    transition: padding 100ms;
+    cursor: pointer;
+}
+
+.option:hover,
+.option.selected {
+    padding: 2px;
+}
+
+.option:hover {
+    border-color: var(--primary5);
+}
+
+.option.selected {
+    border-color: var(--primary4);
+}
+
+.colorBox {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+}
+
+.option:hover .colorBox,
+.option.selected .colorBox {
+    border: 1px solid var(--primary3);
+}
+
+.root.hasError .option {
+    border-color: #de3130;
+}

--- a/src/components/color-select/color-select.module.scss
+++ b/src/components/color-select/color-select.module.scss
@@ -1,12 +1,22 @@
+:where(.root) {
+    /* Default styles. Customize them by passing a className to the component. */
+    --option-size: 24px;
+    --border-color: #bdbdbd;
+    --border-color-hover: #212121;
+    --border-color-selected: #757575;
+    --border-color-error: #ff0000;
+}
+
 .root {
     display: flex;
+    flex-wrap: wrap;
     gap: 8px;
 }
 
 .option {
-    height: 20px;
-    width: 20px;
-    border: 1px solid var(--primary3);
+    height: var(--option-size);
+    width: var(--option-size);
+    border: 1px solid var(--border-color);
     border-radius: 50%;
     transition: padding 100ms;
     cursor: pointer;
@@ -18,11 +28,11 @@
 }
 
 .option:hover {
-    border-color: var(--primary5);
+    border-color: var(--border-color-hover);
 }
 
 .option.selected {
-    border-color: var(--primary4);
+    border-color: var(--border-color-selected);
 }
 
 .colorBox {
@@ -33,9 +43,9 @@
 
 .option:hover .colorBox,
 .option.selected .colorBox {
-    border: 1px solid var(--primary3);
+    border: 1px solid var(--border-color);
 }
 
 .root.hasError .option {
-    border-color: #de3130;
+    border-color: var(--border-color-error);
 }

--- a/src/components/color-select/color-select.tsx
+++ b/src/components/color-select/color-select.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames';
+
+import styles from './color-select.module.scss';
+
+export interface ColorSelectOption {
+    id: string;
+    color: string;
+}
+
+export interface ColorSelectProps {
+    options: ColorSelectOption[];
+    selectedId: string;
+    onChange: (id: string) => void;
+    hasError?: boolean;
+}
+
+export const ColorSelect = ({ options, selectedId, onChange, hasError }: ColorSelectProps) => {
+    return (
+        <div className={classNames(styles.root, { [styles.hasError]: hasError })}>
+            {options.map((option) => (
+                <button
+                    key={option.id}
+                    className={classNames(styles.option, {
+                        [styles.selected]: selectedId === option.id,
+                    })}
+                    onClick={() => onChange(option.id)}
+                >
+                    <div
+                        className={styles.colorBox}
+                        style={{ backgroundColor: option.color }}
+                    ></div>
+                </button>
+            ))}
+        </div>
+    );
+};

--- a/src/components/color-select/color-select.tsx
+++ b/src/components/color-select/color-select.tsx
@@ -12,11 +12,18 @@ export interface ColorSelectProps {
     selectedId: string;
     onChange: (id: string) => void;
     hasError?: boolean;
+    className?: string;
 }
 
-export const ColorSelect = ({ options, selectedId, onChange, hasError }: ColorSelectProps) => {
+export const ColorSelect = ({
+    options,
+    selectedId,
+    onChange,
+    hasError,
+    className,
+}: ColorSelectProps) => {
     return (
-        <div className={classNames(styles.root, { [styles.hasError]: hasError })}>
+        <div className={classNames(styles.root, { [styles.hasError]: hasError }, className)}>
             {options.map((option) => (
                 <button
                     key={option.id}

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -384,3 +384,11 @@
     --thumb-focus-ring-color: #116dff;
     font: var(--paragraph3);
 }
+
+.colorSelect {
+    --option-size: 20px;
+    --border-color: var(--primary3);
+    --border-color-hover: var(--primary5);
+    --border-color-selected: var(--primary4);
+    --border-color-error: #de3130;
+}


### PR DESCRIPTION
<img width="526" alt="Screenshot 2024-10-10 at 17 06 32" src="https://github.com/user-attachments/assets/2f76ea94-0717-4645-9967-a3498d03acae">

`options` is not `string[]` (unfortunately) because for products it's allowed to add colors with the same color value.
What must be unique is the name given to color. So we will use name as the color id.