### PR TITLE
refactor: product filters in URL search params

### DIFF
--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { getEcomApi } from '~/api/ecom-api';
 import { EcomApiErrorCodes } from '~/api/types';
 import {
-    productFiltersSearchParamsConverter,
+    productFiltersFromSearchParams,
     useAppliedProductFilters,
 } from '~/api/use-product-filters';
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
@@ -46,7 +46,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     ] = await Promise.all([
         api.getCategoryBySlug(categorySlug),
         api.getProductsByCategory(categorySlug, {
-            filters: productFiltersSearchParamsConverter.fromSearchParams(url.searchParams),
+            filters: productFiltersFromSearchParams(url.searchParams),
         }),
         api.getAllCategories(),
         api.getProductPriceBounds(categorySlug),

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -9,10 +9,7 @@ import {
 import classNames from 'classnames';
 import { getEcomApi } from '~/api/ecom-api';
 import { EcomApiErrorCodes } from '~/api/types';
-import {
-    productFiltersFromSearchParams,
-    useAppliedProductFilters,
-} from '~/api/use-product-filters';
+import { productFiltersFromSearchParams, useAppliedProductFilters } from '~/api/product-filters';
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
 import { CategoryLink } from '~/components/category-link/category-link';
 import { ErrorPage } from '~/components/error-page/error-page';

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -10,8 +10,8 @@ import classNames from 'classnames';
 import { getEcomApi } from '~/api/ecom-api';
 import { EcomApiErrorCodes } from '~/api/types';
 import {
-    parseProductFiltersFromUrlSearchParams,
-    useProductFilters,
+    productFiltersSearchParamsConverter,
+    useAppliedProductFilters,
 } from '~/api/use-product-filters';
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
 import { CategoryLink } from '~/components/category-link/category-link';
@@ -46,7 +46,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     ] = await Promise.all([
         api.getCategoryBySlug(categorySlug),
         api.getProductsByCategory(categorySlug, {
-            filters: parseProductFiltersFromUrlSearchParams(url.searchParams),
+            filters: productFiltersSearchParamsConverter.fromSearchParams(url.searchParams),
         }),
         api.getAllCategories(),
         api.getProductPriceBounds(categorySlug),
@@ -88,8 +88,8 @@ export default function ProductsPage() {
 
     const breadcrumbs = useBreadcrumbs();
 
-    const { filters, someFiltersApplied, applyFilters, clearFilters, clearAllFilters } =
-        useProductFilters();
+    const { appliedFilters, someFiltersApplied, clearFilters, clearAllFilters } =
+        useAppliedProductFilters();
 
     const currency = categoryProducts.items[0]?.priceData?.currency ?? 'USD';
 
@@ -179,8 +179,6 @@ export default function ProductsPage() {
                                     Filters
                                 </h2>
                                 <ProductFilters
-                                    appliedFilters={filters}
-                                    onFiltersChange={applyFilters}
                                     lowestPrice={productPriceBounds.lowest}
                                     highestPrice={productPriceBounds.highest}
                                     currency={currency}
@@ -201,7 +199,7 @@ export default function ProductsPage() {
                     {someFiltersApplied && (
                         <AppliedProductFilters
                             className={styles.appliedFilters}
-                            appliedFilters={filters}
+                            appliedFilters={appliedFilters}
                             onClearFilters={clearFilters}
                             onClearAllFilters={clearAllFilters}
                             currency={currency}

--- a/src/api/product-filters.ts
+++ b/src/api/product-filters.ts
@@ -39,7 +39,7 @@ export function useAppliedProductFilters() {
     };
 }
 
-export function productFiltersFromSearchParams(params: URLSearchParams) {
+export function productFiltersFromSearchParams(params: URLSearchParams): IProductFilters {
     const minPrice = params.get(ProductFilter.minPrice);
     const maxPrice = params.get(ProductFilter.maxPrice);
     const minPriceNumber = Number(minPrice);
@@ -50,7 +50,10 @@ export function productFiltersFromSearchParams(params: URLSearchParams) {
     };
 }
 
-export function searchParamsFromProductFilters({ minPrice, maxPrice }: IProductFilters) {
+export function searchParamsFromProductFilters({
+    minPrice,
+    maxPrice,
+}: IProductFilters): URLSearchParams {
     const params = new URLSearchParams();
     if (minPrice !== undefined) params.set(ProductFilter.minPrice, minPrice.toString());
     if (maxPrice !== undefined) params.set(ProductFilter.maxPrice, maxPrice.toString());

--- a/src/api/use-product-filters.ts
+++ b/src/api/use-product-filters.ts
@@ -1,13 +1,12 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from '@remix-run/react';
 import { IProductFilters, ProductFilter } from '~/api/types';
-import type { SearchParamsStateConverter } from '../utils/use-search-params-state';
 
 export function useAppliedProductFilters() {
     const [searchParams, setSearchParams] = useSearchParams();
 
     const appliedFilters = useMemo(
-        () => productFiltersSearchParamsConverter.fromSearchParams(searchParams),
+        () => productFiltersFromSearchParams(searchParams),
         [searchParams],
     );
 
@@ -40,21 +39,20 @@ export function useAppliedProductFilters() {
     };
 }
 
-export const productFiltersSearchParamsConverter: SearchParamsStateConverter<IProductFilters> = {
-    fromSearchParams: (params) => {
-        const minPrice = params.get(ProductFilter.minPrice);
-        const maxPrice = params.get(ProductFilter.maxPrice);
-        const minPriceNumber = Number(minPrice);
-        const maxPriceNumber = Number(maxPrice);
-        return {
-            minPrice: minPrice && !Number.isNaN(minPriceNumber) ? minPriceNumber : undefined,
-            maxPrice: maxPrice && !Number.isNaN(maxPriceNumber) ? maxPriceNumber : undefined,
-        };
-    },
-    toSearchParams: ({ minPrice, maxPrice }) => {
-        const params = new URLSearchParams();
-        if (minPrice !== undefined) params.set(ProductFilter.minPrice, minPrice.toString());
-        if (maxPrice !== undefined) params.set(ProductFilter.maxPrice, maxPrice.toString());
-        return params;
-    },
-};
+export function productFiltersFromSearchParams(params: URLSearchParams) {
+    const minPrice = params.get(ProductFilter.minPrice);
+    const maxPrice = params.get(ProductFilter.maxPrice);
+    const minPriceNumber = Number(minPrice);
+    const maxPriceNumber = Number(maxPrice);
+    return {
+        minPrice: minPrice && !Number.isNaN(minPriceNumber) ? minPriceNumber : undefined,
+        maxPrice: maxPrice && !Number.isNaN(maxPriceNumber) ? maxPriceNumber : undefined,
+    };
+}
+
+export function searchParamsFromProductFilters({ minPrice, maxPrice }: IProductFilters) {
+    const params = new URLSearchParams();
+    if (minPrice !== undefined) params.set(ProductFilter.minPrice, minPrice.toString());
+    if (maxPrice !== undefined) params.set(ProductFilter.maxPrice, maxPrice.toString());
+    return params;
+}

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -1,8 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { IProductFilters } from '~/api/types';
-import { productFiltersSearchParamsConverter } from '~/api/use-product-filters';
-import { formatPrice } from '~/utils';
-import { useSearchParamsState } from '~/utils/use-search-params-state';
+import {
+    productFiltersFromSearchParams,
+    searchParamsFromProductFilters,
+} from '~/api/use-product-filters';
+import { formatPrice, mergeUrlSearchParams } from '~/utils';
+import { useSearchParamsOptimistic } from '~/utils/use-search-params-state';
 import { Accordion } from '../accordion/accordion';
 import { RangeSlider } from '../range-slider/range-slider';
 
@@ -13,10 +16,15 @@ interface ProductFiltersProps {
 }
 
 export const ProductFilters = ({ lowestPrice, highestPrice, currency }: ProductFiltersProps) => {
-    const [filters, setFilters] = useSearchParamsState(productFiltersSearchParamsConverter);
+    const [searchParams, setSearchParams] = useSearchParamsOptimistic();
+
+    const filters = useMemo(() => productFiltersFromSearchParams(searchParams), [searchParams]);
 
     const handleFiltersChange = (changed: Partial<IProductFilters>) => {
-        setFilters({ ...filters, ...changed });
+        const newParams = searchParamsFromProductFilters({ ...filters, ...changed });
+        setSearchParams((params) => mergeUrlSearchParams(params, newParams), {
+            preventScrollReset: true,
+        });
     };
 
     const formatPriceValue = useCallback(

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -3,7 +3,7 @@ import { IProductFilters } from '~/api/types';
 import {
     productFiltersFromSearchParams,
     searchParamsFromProductFilters,
-} from '~/api/use-product-filters';
+} from '~/api/product-filters';
 import { formatPrice, mergeUrlSearchParams } from '~/utils';
 import { useSearchParamsOptimistic } from '~/utils/use-search-params-state';
 import { Accordion } from '../accordion/accordion';

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -1,48 +1,28 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useNavigation } from '@remix-run/react';
+import { useCallback } from 'react';
 import { IProductFilters } from '~/api/types';
+import { productFiltersSearchParamsConverter } from '~/api/use-product-filters';
 import { formatPrice } from '~/utils';
+import { useSearchParamsState } from '~/utils/use-search-params-state';
 import { Accordion } from '../accordion/accordion';
 import { RangeSlider } from '../range-slider/range-slider';
 
 interface ProductFiltersProps {
-    appliedFilters: IProductFilters;
-    onFiltersChange: (filters: IProductFilters) => void;
     lowestPrice: number;
     highestPrice: number;
     currency: string;
 }
 
-export const ProductFilters = ({
-    appliedFilters,
-    onFiltersChange,
-    lowestPrice,
-    highestPrice,
-    currency,
-}: ProductFiltersProps) => {
-    const navigation = useNavigation();
-
-    // Allows updating the UI optimistically while Remix navigates to the URL
-    // with updated parameters.
-    const [filters, setFilters] = useState(appliedFilters);
+export const ProductFilters = ({ lowestPrice, highestPrice, currency }: ProductFiltersProps) => {
+    const [filters, setFilters] = useSearchParamsState(productFiltersSearchParamsConverter);
 
     const handleFiltersChange = (changed: Partial<IProductFilters>) => {
-        const newFilters = { ...filters, ...changed };
-        setFilters(newFilters);
-        onFiltersChange(newFilters);
+        setFilters({ ...filters, ...changed });
     };
 
     const formatPriceValue = useCallback(
         (price: number) => formatPrice(price, currency),
         [currency],
     );
-
-    // Synchronize filters on back/forward browser button clicks.
-    useEffect(() => {
-        if (navigation.state !== 'loading') {
-            setFilters(appliedFilters);
-        }
-    }, [navigation.state, appliedFilters]);
 
     return (
         <Accordion

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,3 +86,34 @@ export function routeLocationToUrl(location: Location, origin: string): URL {
     url.hash = location.hash;
     return url;
 }
+
+/**
+ * Merges multiple URLSearchParams instances into one URLSearchParams.
+ *
+ * For entries with the same key, values from subsequent URLSearchParams
+ * instances will overwrite the earlier ones. For example:
+ * ```js
+ * const a = new URLSearchParams([['foo', '1'], ['foo', '2']])
+ * const b = new URLSearchParams([['foo', '3'], ['foo', '4']])
+ * const c = mergeUrlSearchParams(a, b);
+ * c.toString(); // 'foo=3&foo=4'
+ * ```
+ */
+export function mergeUrlSearchParams(...paramsArr: URLSearchParams[]): URLSearchParams {
+    const result = new URLSearchParams();
+
+    for (const params of paramsArr) {
+        const overriddenParams = new Set<string>();
+
+        for (const [key, value] of params.entries()) {
+            if (result.has(key) && !overriddenParams.has(key)) {
+                result.delete(key);
+                overriddenParams.add(key);
+            }
+
+            result.append(key, value);
+        }
+    }
+
+    return result;
+}

--- a/src/utils/use-search-params-state.ts
+++ b/src/utils/use-search-params-state.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { NavigateOptions } from 'react-router';
+import { useNavigation, useSearchParams } from '@remix-run/react';
+import { mergeUrlSearchParams } from './index';
+
+export interface SearchParamsStateConverter<S> {
+    fromSearchParams: (params: URLSearchParams) => S;
+    toSearchParams: (state: S) => URLSearchParams;
+}
+
+export function useSearchParamsState<S>(
+    converter: SearchParamsStateConverter<S>,
+    navigateOptions: NavigateOptions = { preventScrollReset: true },
+) {
+    const navigation = useNavigation();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    // Allows updating the UI optimistically
+    // while Remix navigates to the URL with updated parameters.
+    const [state, setState] = useState(() => converter.fromSearchParams(searchParams));
+
+    const handleChange = useCallback(
+        (newState: S) => {
+            setState(newState);
+            setSearchParams((prevParams) => {
+                return mergeUrlSearchParams(prevParams, converter.toSearchParams(newState));
+            }, navigateOptions);
+        },
+        [setSearchParams, converter, navigateOptions],
+    );
+
+    // Synchronize local state with URL search params on back/forward browser button clicks.
+    useEffect(() => {
+        if (navigation.state !== 'loading') {
+            setState(converter.fromSearchParams(searchParams));
+        }
+    }, [navigation.state, searchParams, converter]);
+
+    return [state, handleChange] as const;
+}

--- a/src/utils/use-search-params-state.ts
+++ b/src/utils/use-search-params-state.ts
@@ -8,6 +8,16 @@ export interface SearchParamsStateConverter<S> {
     toSearchParams: (state: S) => URLSearchParams;
 }
 
+/**
+ * Helper to manage the state that lives in URL search params.
+ * Search params are not updated immediately
+ * because changing them causes a Remix navigation and loaders reloading.
+ * This hooks provides a local React state to apply changes to URL optimistically
+ * and ensures it's up to date with the values in URL.
+ *
+ * @param converter Converts specific state from search params and vice versa.
+ * @param navigateOptions Router navigation options when changing search params.
+ */
 export function useSearchParamsState<S>(
     converter: SearchParamsStateConverter<S>,
     navigateOptions: NavigateOptions = { preventScrollReset: true },
@@ -15,8 +25,6 @@ export function useSearchParamsState<S>(
     const navigation = useNavigation();
     const [searchParams, setSearchParams] = useSearchParams();
 
-    // Allows updating the UI optimistically
-    // while Remix navigates to the URL with updated parameters.
     const [state, setState] = useState(() => converter.fromSearchParams(searchParams));
 
     const handleChange = useCallback(

--- a/src/utils/use-search-params-state.ts
+++ b/src/utils/use-search-params-state.ts
@@ -1,48 +1,33 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { NavigateOptions } from 'react-router';
 import { useNavigation, useSearchParams } from '@remix-run/react';
-import { mergeUrlSearchParams } from './index';
-
-export interface SearchParamsStateConverter<S> {
-    fromSearchParams: (params: URLSearchParams) => S;
-    toSearchParams: (state: S) => URLSearchParams;
-}
 
 /**
- * Helper to manage the state that lives in URL search params.
- * Search params are not updated immediately
- * because changing them causes a Remix navigation and loaders reloading.
- * This hooks provides a local React state to apply changes to URL optimistically
- * and ensures it's up to date with the values in URL.
- *
- * @param converter Converts specific state from search params and vice versa.
- * @param navigateOptions Router navigation options when changing search params.
+ * Similar to `useSearchParams` from Remix, but allows to update search params optimistically.
  */
-export function useSearchParamsState<S>(
-    converter: SearchParamsStateConverter<S>,
-    navigateOptions: NavigateOptions = { preventScrollReset: true },
-) {
+export function useSearchParamsOptimistic() {
     const navigation = useNavigation();
     const [searchParams, setSearchParams] = useSearchParams();
 
-    const [state, setState] = useState(() => converter.fromSearchParams(searchParams));
+    const [optimisticSearchParams, setOptimisticSearchParams] = useState(searchParams);
 
-    const handleChange = useCallback(
-        (newState: S) => {
-            setState(newState);
-            setSearchParams((prevParams) => {
-                return mergeUrlSearchParams(prevParams, converter.toSearchParams(newState));
-            }, navigateOptions);
+    const handleSearchParamsChange = useCallback(
+        (
+            params: URLSearchParams | ((prevParams: URLSearchParams) => URLSearchParams),
+            options?: NavigateOptions,
+        ) => {
+            setOptimisticSearchParams(params);
+            setSearchParams(params, options);
         },
-        [setSearchParams, converter, navigateOptions],
+        [setSearchParams],
     );
 
-    // Synchronize local state with URL search params on back/forward browser button clicks.
+    // Synchronize search params on back/forward browser button clicks.
     useEffect(() => {
         if (navigation.state !== 'loading') {
-            setState(converter.fromSearchParams(searchParams));
+            setOptimisticSearchParams(searchParams);
         }
-    }, [navigation.state, searchParams, converter]);
+    }, [navigation.state, searchParams]);
 
-    return [state, handleChange] as const;
+    return [optimisticSearchParams, handleSearchParamsChange] as const;
 }


### PR DESCRIPTION
Add `useSearchParamsOptimistic` hook to simplify working with the state that lives in URL search params.
This will come in handy for other states in URL, such as product sorting.