### PR TITLE
feat: support product variants

### DIFF
--- a/app/routes/product-details.$productSlug/route.module.scss
+++ b/app/routes/product-details.$productSlug/route.module.scss
@@ -35,6 +35,13 @@
     line-height: 1.5;
 }
 
+.productOptions {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 14px;
+}
+
 .quantity {
     margin-top: 20px;
 }

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { useState } from 'react';
 import { useAddToCart } from '~/api/api-hooks';
 import { getEcomApi } from '~/api/ecom-api';
-import { EcomApiErrorCodes } from '~/api/types';
+import { AddToCartOptions, EcomApiErrorCodes } from '~/api/types';
 import { Accordion } from '~/components/accordion/accordion';
 import { Breadcrumbs } from '~/components/breadcrumbs/breadcrumbs';
 import { useCartOpen } from '~/components/cart/cart-open-context';
@@ -19,11 +19,21 @@ import { ErrorPage } from '~/components/error-page/error-page';
 import { ProductImages } from '~/components/product-images/product-images';
 import { ProductPrice } from '~/components/product-price/product-price';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
+import { ProductOption } from '~/components/product-option/product-option';
 import { ShareProductLinks } from '~/components/share-product-links/share-product-links';
 import { ROUTES } from '~/router/config';
 import { BreadcrumbData, RouteHandle } from '~/router/types';
 import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
+import {
+    getMedia,
+    getPriceData,
+    getSelectedVariant,
+    getSKU,
+    isOutOfStock,
+    selectedChoicesToVariantChoices,
+} from '~/utils/product-utils';
 import { useBreadcrumbs } from '~/router/use-breadcrumbs';
+
 import styles from './route.module.scss';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
@@ -79,13 +89,43 @@ export default function ProductDetailsPage() {
     const cartOpener = useCartOpen();
     const { trigger: addToCart, isMutating: isAddingToCart } = useAddToCart();
 
+    const getInitialSelectedChoices = () => {
+        const result: Record<string, products.Choice | undefined> = {};
+        for (const option of product.productOptions ?? []) {
+            if (option.name) {
+                result[option.name] = option?.choices?.length === 1 ? option.choices[0] : undefined;
+            }
+        }
+
+        return result;
+    };
+
+    const [selectedChoices, setSelectedChoices] = useState(() => getInitialSelectedChoices());
     const [quantity, setQuantity] = useState(1);
+    const [addToCartAttempted, setAddToCartAttempted] = useState(false);
+
+    const outOfStock = isOutOfStock(product, selectedChoices);
+    const priceData = getPriceData(product, selectedChoices);
+    const sku = getSKU(product, selectedChoices);
+    const media = getMedia(product, selectedChoices);
 
     const handleAddToCartClick = () => {
+        setAddToCartAttempted(true);
+
+        if (Object.values(selectedChoices).includes(undefined)) return;
+
+        const selectedVariant = getSelectedVariant(product, selectedChoices);
+
+        const options: AddToCartOptions =
+            product.manageVariants && selectedVariant?._id
+                ? { variantId: selectedVariant._id }
+                : { options: selectedChoicesToVariantChoices(product, selectedChoices) };
+
         addToCart(
             {
                 id: product._id!,
                 quantity,
+                options,
             },
             {
                 onSuccess: () => cartOpener.setIsOpen(true),
@@ -93,24 +133,30 @@ export default function ProductDetailsPage() {
         );
     };
 
-    const isOutOfStock = product.stock?.inventoryStatus === products.InventoryStatus.OUT_OF_STOCK;
+    const handleOptionChange = (optionName: string, newChoice: products.Choice) => {
+        setQuantity(1);
+        setSelectedChoices((prev) => ({
+            ...prev,
+            [optionName]: newChoice,
+        }));
+    };
 
     return (
         <div className={styles.page}>
             <Breadcrumbs breadcrumbs={breadcrumbs} />
 
             <div className={styles.content}>
-                <ProductImages media={product.media} />
+                <ProductImages media={media} />
 
                 <div>
                     <h1 className={styles.productName}>{product.name}</h1>
-                    {product.sku && <p className={styles.sku}>SKU: {product.sku}</p>}
+                    {sku && <p className={styles.sku}>SKU: {sku}</p>}
 
-                    {product.priceData && (
+                    {priceData && (
                         <ProductPrice
                             className={styles.price}
-                            price={product.priceData.formatted?.price}
-                            discountedPrice={product.priceData.formatted?.discountedPrice}
+                            price={priceData.formatted?.price}
+                            discountedPrice={priceData.formatted?.discountedPrice}
                         />
                     )}
 
@@ -121,19 +167,43 @@ export default function ProductDetailsPage() {
                         />
                     )}
 
+                    {product.productOptions && product.productOptions.length > 0 && (
+                        <div className={styles.productOptions}>
+                            {product.productOptions.map((option) => (
+                                <ProductOption
+                                    key={option.name}
+                                    error={
+                                        addToCartAttempted &&
+                                        selectedChoices[option.name!] === undefined
+                                            ? `Select ${option.name}`
+                                            : undefined
+                                    }
+                                    option={option}
+                                    selectedChoice={selectedChoices[option.name!]}
+                                    onChange={(choice) => handleOptionChange(option.name!, choice)}
+                                />
+                            ))}
+                        </div>
+                    )}
+
                     <div className={styles.quantity}>
                         <label htmlFor="quantity" className={styles.quantityLabel}>
                             Quantity
                         </label>
-                        <QuantityInput id="quantity" value={quantity} onChange={setQuantity} />
+                        <QuantityInput
+                            id="quantity"
+                            value={quantity}
+                            onChange={setQuantity}
+                            disabled={outOfStock}
+                        />
                     </div>
 
                     <button
                         className={classNames('button', 'primaryButton', styles.addToCartButton)}
                         onClick={handleAddToCartClick}
-                        disabled={isOutOfStock || isAddingToCart}
+                        disabled={outOfStock || isAddingToCart}
                     >
-                        {isOutOfStock ? 'Out of stock' : 'Add to Cart'}
+                        {outOfStock ? 'Out of stock' : 'Add to Cart'}
                     </button>
 
                     {product.additionalInfoSections &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@wix/stores": "^1.0.238",
         "@wix/stores_products": "^1.0.54",
         "classnames": "^2.5.1",
+        "fast-deep-equal": "^3.1.3",
         "framer-motion": "^11.11.1",
         "isbot": "^5.1.17",
         "js-cookie": "^3.0.5",
@@ -6678,7 +6679,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@wix/stores": "^1.0.238",
     "@wix/stores_products": "^1.0.54",
     "classnames": "^2.5.1",
+    "fast-deep-equal": "^3.1.3",
     "framer-motion": "^11.11.1",
     "isbot": "^5.1.17",
     "js-cookie": "^3.0.5",

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -3,6 +3,7 @@ import useSwr, { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { findItemIdInCart } from './cart-helpers';
 import { useEcomAPI } from './ecom-api-context-provider';
+import { AddToCartOptions } from './types';
 
 export const useCartData = () => {
     const ecomApi = useEcomAPI();
@@ -37,14 +38,18 @@ export const useCartTotals = () => {
     return cartTotals;
 };
 
-type Args = { id: string; quantity: number };
+interface AddToCartArgs {
+    id: string;
+    quantity: number;
+    options?: AddToCartOptions;
+}
 
 export const useAddToCart = () => {
     const ecomApi = useEcomAPI();
     const { data: cart } = useCartData();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: Args & { options?: Record<string, string> } }) => {
+        async (_key: Key, { arg }: { arg: AddToCartArgs }) => {
             const itemInCart = cart ? findItemIdInCart(cart, arg.id, arg.options) : undefined;
 
             if (itemInCart) {
@@ -71,11 +76,16 @@ export const useAddToCart = () => {
     );
 };
 
+interface UpdateCartItemQuantityArgs {
+    id: string;
+    quantity: number;
+}
+
 export const useUpdateCartItemQuantity = () => {
     const ecomApi = useEcomAPI();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: Args }) => {
+        async (_key: Key, { arg }: { arg: UpdateCartItemQuantityArgs }) => {
             const response = await ecomApi.updateCartItemQuantity(arg.id, arg.quantity);
             if (response.status === 'failure') {
                 throw response.error;

--- a/src/api/cart-helpers.ts
+++ b/src/api/cart-helpers.ts
@@ -1,30 +1,23 @@
 import ecom from '@wix/ecom';
-import { CartItem, CartTotals } from './types';
+import deepEqual from 'fast-deep-equal';
+import { AddToCartOptions, Cart, CartItem, CartTotals } from './types';
 
 export function findItemIdInCart(
-    cart: ecom.cart.Cart & ecom.cart.CartNonNullableFields,
+    { lineItems }: Cart,
     catalogItemId: string,
-    options?: Record<string, string>,
+    options?: AddToCartOptions,
 ) {
-    return cart.lineItems.find((it) => {
+    return lineItems.find((it) => {
         if (it.catalogReference?.catalogItemId !== catalogItemId) {
             return false;
         }
-        const catalogOptions = it.catalogReference?.options?.options;
-        const optionsLength = options ? Object.keys(options).length : 0;
-        const catalogOptionsLength = catalogOptions ? Object.keys(catalogOptions).length : 0;
-        if (optionsLength !== catalogOptionsLength) {
-            return false;
+
+        if (options && 'variantId' in options) {
+            return it.catalogReference?.options?.variantId === options.variantId;
         }
-        if (!options || !catalogOptions) {
-            return true;
-        }
-        for (const optionName of Object.keys(options)) {
-            if (options[optionName] !== catalogOptions[optionName]) {
-                return false;
-            }
-        }
-        return true;
+
+        const lineItemOptions = it.catalogReference?.options?.options;
+        return deepEqual(lineItemOptions, options?.options);
     });
 }
 

--- a/src/api/ecom-api.ts
+++ b/src/api/ecom-api.ts
@@ -183,9 +183,9 @@ function createApi(): EcomAPI {
                             catalogReference: {
                                 catalogItemId: id,
                                 appId: WIX_STORES_APP_ID,
-                                options: { options: options },
+                                options,
                             },
-                            quantity: quantity,
+                            quantity,
                         },
                     ],
                 });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -85,6 +85,10 @@ interface GetProductsByCategoryOptions {
     sortBy?: ProductSortBy;
 }
 
+export type AddToCartOptions =
+    | { variantId: string }
+    | { options: Record<string, string | undefined> };
+
 export type EcomAPI = {
     getProductsByCategory: (
         categorySlug: string,
@@ -107,7 +111,7 @@ export type EcomAPI = {
     addToCart: (
         id: string,
         quantity: number,
-        options?: Record<string, string>,
+        options?: AddToCartOptions,
     ) => Promise<EcomAPIResponse<Cart>>;
     checkout: () => Promise<EcomAPIResponse<{ checkoutUrl: string }>>;
     getAllCategories: () => Promise<EcomAPIResponse<Collection[]>>;

--- a/src/components/cart/cart-item/cart-item.module.scss
+++ b/src/components/cart/cart-item/cart-item.module.scss
@@ -112,7 +112,7 @@
 }
 
 .unavailableIcon {
-    color: #df3131;
+    color: var(--error);
     width: 20px;
     height: 20px;
 }

--- a/src/components/product-images/product-images.tsx
+++ b/src/components/product-images/product-images.tsx
@@ -1,6 +1,6 @@
 import { products } from '@wix/stores';
 import styles from './product-images.module.scss';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { ImagePlaceholderIcon } from '../icons';
 import { getClickableElementAttributes } from '~/utils';
@@ -13,6 +13,12 @@ export const ProductImages = ({ media }: ProductImagesProps) => {
     const [selectedImage, setSelectedImage] = useState<products.MediaItem | undefined>(
         media?.mainMedia,
     );
+
+    // The media can change when another product variant was selected and it has
+    // a different set of media items. In this case make sure the selected image is refreshed.
+    useEffect(() => {
+        setSelectedImage(media?.mainMedia);
+    }, [media]);
 
     const imageItems = media?.items?.filter((item) => item.image !== undefined);
 

--- a/src/components/product-option/product-option.module.scss
+++ b/src/components/product-option/product-option.module.scss
@@ -1,0 +1,13 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.error {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--error);
+    font: var(--paragraph3);
+}

--- a/src/components/product-option/product-option.tsx
+++ b/src/components/product-option/product-option.tsx
@@ -1,0 +1,72 @@
+import { products } from '@wix/stores';
+import { ColorSelect } from '~/components/color-select/color-select';
+import { Select, SelectItem } from '~/components/select/select';
+import { getChoiceValue } from '~/utils/product-utils';
+import { ErrorIcon } from '../icons';
+
+import styles from './product-option.module.scss';
+
+export interface ProductOptionProps {
+    option: products.ProductOption;
+    selectedChoice: products.Choice | undefined;
+    error: string | undefined;
+    onChange: (choice: products.Choice) => void;
+}
+
+export const ProductOption = ({ option, selectedChoice, error, onChange }: ProductOptionProps) => {
+    const { name, optionType, choices } = option;
+
+    if (name === undefined || choices === undefined || optionType === undefined) {
+        return null;
+    }
+
+    const handleChange = (value: string) => {
+        const newSelectedChoice = choices.find((c) => getChoiceValue(optionType, c) === value);
+        if (newSelectedChoice) {
+            onChange(newSelectedChoice);
+        }
+    };
+
+    const hasError = error !== undefined;
+
+    return (
+        <div className={styles.root}>
+            <div className="paragraph2">
+                {name}
+                {selectedChoice && `: ${selectedChoice.description}`}
+            </div>
+
+            {optionType === products.OptionType.color ? (
+                <ColorSelect
+                    className="colorSelect"
+                    // `description` is what identifies the color choice. It's the unique color name.
+                    // `value` is the color value, which can be repeated in different color choices.
+                    options={choices.map((c) => ({ id: c.description!, color: c.value! }))}
+                    selectedId={selectedChoice?.description ?? ''}
+                    onChange={handleChange}
+                    hasError={hasError}
+                />
+            ) : (
+                <Select
+                    placeholder={`Select ${name}`}
+                    value={selectedChoice?.value ?? ''}
+                    onValueChange={handleChange}
+                    hasError={hasError}
+                >
+                    {choices.map((c) => (
+                        <SelectItem key={c.value} value={c.value!}>
+                            {c.description}
+                        </SelectItem>
+                    ))}
+                </Select>
+            )}
+
+            {hasError && (
+                <div className={styles.error}>
+                    <ErrorIcon width={18} height={18} />
+                    {error}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/components/select/select.module.scss
+++ b/src/components/select/select.module.scss
@@ -16,6 +16,10 @@
     box-shadow: none;
 }
 
+.trigger.hasError {
+    border-color: var(--error);
+}
+
 .trigger:hover,
 .trigger:focus,
 .trigger[data-state='open'] {

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -16,6 +16,7 @@ export interface SelectProps<V extends string> {
      * By default the selected item's text will be rendered.
      */
     renderValue?: (value: V) => React.ReactNode;
+    hasError?: boolean;
 }
 
 export const Select = <V extends string>({
@@ -26,9 +27,12 @@ export const Select = <V extends string>({
     className,
     dropdownClassName,
     renderValue,
+    hasError,
 }: SelectProps<V>) => (
     <RadixSelect.Root value={value} onValueChange={onValueChange}>
-        <RadixSelect.Trigger className={classNames(styles.trigger, className)}>
+        <RadixSelect.Trigger
+            className={classNames(styles.trigger, { [styles.hasError]: hasError }, className)}
+        >
             <RadixSelect.Value placeholder={placeholder}>{renderValue?.(value)}</RadixSelect.Value>
             <RadixSelect.Icon className={styles.triggerIcon}>
                 <DropdownIcon width={12} />

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,6 +1,7 @@
 :root {
     --white: #ffffff;
     --black: #000000;
+    --error: #df3131;
 
     --primary1: #fef9ec;
     --primary2: #ffefc7;

--- a/src/utils/product-utils.ts
+++ b/src/utils/product-utils.ts
@@ -1,0 +1,92 @@
+import { SerializeFrom } from '@remix-run/node';
+import deepEqual from 'fast-deep-equal';
+import { products as wixStoresProducts } from '@wix/stores';
+import { Product } from '~/api/types';
+
+export function isOutOfStock(
+    product: Product | SerializeFrom<Product>,
+    selectedChoices: Record<string, wixStoresProducts.Choice | undefined> = {},
+): boolean {
+    if (product.manageVariants) {
+        const selectedVariant = getSelectedVariant(product, selectedChoices);
+        if (selectedVariant !== undefined) {
+            return selectedVariant?.stock?.inStock === false;
+        }
+    }
+
+    return product.stock?.inventoryStatus === wixStoresProducts.InventoryStatus.OUT_OF_STOCK;
+}
+
+export function getPriceData(
+    product: Product | SerializeFrom<Product>,
+    selectedChoices: Record<string, wixStoresProducts.Choice | undefined> = {},
+): Product['priceData'] {
+    if (product.manageVariants) {
+        const selectedVariant = getSelectedVariant(product, selectedChoices);
+        return selectedVariant?.variant?.priceData ?? product.priceData;
+    }
+
+    return product.priceData;
+}
+
+export function getSKU(
+    product: Product | SerializeFrom<Product>,
+    selectedChoices: Record<string, wixStoresProducts.Choice | undefined> = {},
+): Product['sku'] {
+    if (product.manageVariants) {
+        const selectedVariant = getSelectedVariant(product, selectedChoices);
+        return selectedVariant?.variant?.sku ?? product.sku;
+    }
+
+    return product.sku;
+}
+
+export function getSelectedVariant(
+    product: Product | SerializeFrom<Product>,
+    selectedChoices: Record<string, wixStoresProducts.Choice | undefined> = {},
+): wixStoresProducts.Variant | undefined {
+    const selectedChoiceValues = selectedChoicesToVariantChoices(product, selectedChoices);
+    return product.variants?.find((variant) => deepEqual(variant.choices, selectedChoiceValues));
+}
+
+export const getChoiceValue = (
+    optionType: wixStoresProducts.OptionType,
+    choice: wixStoresProducts.Choice,
+): string | undefined => {
+    // for color options, `description` field contains color name and `value` field contains hex color representation
+    // e-commerce SDK for some actions (adding to cart for example) expects color name as selected color value
+    return optionType === wixStoresProducts.OptionType.color ? choice.description : choice.value;
+};
+
+// selected choices is a map of option names to selected choice objects - {'Size': {value: 'Large', visible: true...}}
+// variant choices is a map of option names to selected choice values - {'Size': 'Large'}
+// the name 'variant choices' is used because the same data structure is used for the Variant['choices'] property provided by SDK
+export const selectedChoicesToVariantChoices = (
+    product: Product | SerializeFrom<Product>,
+    selectedChoices: Record<string, wixStoresProducts.Choice | undefined> = {},
+): Record<string, string | undefined> => {
+    const result: Record<string, string | undefined> = {};
+    for (const [optionName, choice] of Object.entries(selectedChoices)) {
+        if (!choice) {
+            result[optionName] = undefined;
+            continue;
+        }
+
+        const option = product.productOptions?.find((option) => option.name === optionName);
+        if (!option?.optionType) continue;
+
+        result[optionName] = getChoiceValue(option.optionType, choice);
+    }
+
+    return result;
+};
+
+export function getMedia(
+    product: Product | SerializeFrom<Product>,
+    selectedChoices: Record<string, wixStoresProducts.Choice | undefined> = {},
+): wixStoresProducts.Media | undefined {
+    const selectedChoiceWithMedia = Object.values(selectedChoices).find(
+        (c) => c?.media?.mainMedia !== undefined,
+    );
+    return selectedChoiceWithMedia?.media ?? product.media;
+}


### PR DESCRIPTION
Copy product variants functionality from https://github.com/codux-templates/e-commerce-remix
The only differences are in styles and components that we use.

PR includes:
- Allow to choose product options.
- Adjust product details depending on the selected options.
- Update API to handle adding product with options to the cart.

To be done:
- Display selected options in cart. I'll do this in a separate PR https://github.com/codux-templates/e-commerce-reclaim/pull/151
- Hidden and out of stock variants. I'll wait for https://github.com/codux-templates/e-commerce-remix/pull/89