### PR TITLE
feat: show product options in cart

### DIFF
--- a/_codux/boards/cart-item/cart-item.board.tsx
+++ b/_codux/boards/cart-item/cart-item.board.tsx
@@ -9,6 +9,16 @@ const mockCartItem: cart.LineItem = {
     image: 'https://static.wixstatic.com/media/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg/v1/fill/w_824,h_1098,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/c837a6_18152edaef9940ca88f446ae94b48a47~mv2.jpg',
     price: { formattedConvertedAmount: '$5.50' },
     fullPrice: { formattedConvertedAmount: '$7.50' },
+    descriptionLines: [
+        {
+            name: { original: 'Size', translated: 'Size' },
+            plainText: { original: 'Middle', translated: 'Middle' },
+        },
+        {
+            name: { original: 'Color', translated: 'Color' },
+            colorInfo: { original: 'green', translated: 'green', code: '#008000' },
+        },
+    ],
 };
 
 const noop = () => {};
@@ -30,7 +40,7 @@ export default createBoard({
         );
     },
     environmentProps: {
-        windowHeight: 145,
+        windowHeight: 200,
         windowWidth: 810,
     },
 });

--- a/src/components/cart/cart-item-options/cart-item-options.module.scss
+++ b/src/components/cart/cart-item-options/cart-item-options.module.scss
@@ -1,0 +1,26 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.moreOptionsButton {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font: var(--paragraph3);
+    cursor: pointer;
+}
+
+.moreOptionsButton:focus,
+.moreOptionsButton:hover {
+    color: var(--secondary3);
+}
+
+.moreOptionsIcon {
+    width: 12px;
+}
+
+.root.expanded .moreOptionsIcon {
+    transform: rotate(180deg);
+}

--- a/src/components/cart/cart-item-options/cart-item-options.tsx
+++ b/src/components/cart/cart-item-options/cart-item-options.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { cart } from '@wix/ecom';
+import classNames from 'classnames';
+import { DropdownIcon } from '~/components/icons';
+
+import styles from './cart-item-options.module.scss';
+
+interface CartItemOptionsProps {
+    options: cart.DescriptionLine[];
+    /**
+     * The maximum amount of options that are visible even in the collapsed state.
+     */
+    visibleOptionsCount: number;
+    className?: string;
+}
+
+export const CartItemOptions = ({
+    options,
+    visibleOptionsCount,
+    className,
+}: CartItemOptionsProps) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const toggleIsExpanded = () => setIsExpanded((prev) => !prev);
+
+    return (
+        <div className={classNames(styles.root, { [styles.expanded]: isExpanded }, className)}>
+            {options.slice(0, isExpanded ? undefined : visibleOptionsCount).map((option) => (
+                <div key={option.name!.translated} className="paragraph3">
+                    {option.name!.translated}:{' '}
+                    {option.colorInfo ? option.colorInfo.translated : option.plainText?.translated}
+                </div>
+            ))}
+
+            {options.length > visibleOptionsCount && (
+                <button className={styles.moreOptionsButton} onClick={toggleIsExpanded}>
+                    {isExpanded ? 'Less Details' : 'More Details'}
+                    <DropdownIcon className={styles.moreOptionsIcon} />
+                </button>
+            )}
+        </div>
+    );
+};

--- a/src/components/cart/cart-item/cart-item.module.scss
+++ b/src/components/cart/cart-item/cart-item.module.scss
@@ -53,31 +53,7 @@
 }
 
 .options {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
     margin-top: 4px;
-}
-
-.moreOptionsButton {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font: var(--paragraph3);
-    cursor: pointer;
-}
-
-.moreOptionsButton:focus,
-.moreOptionsButton:hover {
-    color: var(--secondary3);
-}
-
-.moreOptionsIcon {
-    width: 12px;
-}
-
-.moreOptionsIcon.rotated {
-    transform: rotate(180deg);
 }
 
 .price {

--- a/src/components/cart/cart-item/cart-item.module.scss
+++ b/src/components/cart/cart-item/cart-item.module.scss
@@ -52,6 +52,26 @@
     margin-bottom: 10px;
 }
 
+.options {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 4px;
+}
+
+.moreOptionsButton {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font: var(--paragraph3);
+    cursor: pointer;
+}
+
+.moreOptionsButton:focus,
+.moreOptionsButton:hover {
+    color: var(--secondary3);
+}
+
 .price {
     grid-area: price;
 }

--- a/src/components/cart/cart-item/cart-item.module.scss
+++ b/src/components/cart/cart-item/cart-item.module.scss
@@ -72,6 +72,14 @@
     color: var(--secondary3);
 }
 
+.moreOptionsIcon {
+    width: 12px;
+}
+
+.moreOptionsIcon.rotated {
+    transform: rotate(180deg);
+}
+
 .price {
     grid-area: price;
 }

--- a/src/components/cart/cart-item/cart-item.tsx
+++ b/src/components/cart/cart-item/cart-item.tsx
@@ -1,16 +1,15 @@
+import { useEffect, useMemo, useState } from 'react';
 import { cart } from '@wix/ecom';
 import { media } from '@wix/sdk';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
-import { TrashIcon, ImagePlaceholderIcon, ErrorIcon, DropdownIcon } from '~/components/icons';
+import { TrashIcon, ImagePlaceholderIcon, ErrorIcon } from '~/components/icons';
 import { Spinner } from '~/components/spinner/spinner';
 import { ProductPrice } from '~/components/product-price/product-price';
 import classNames from 'classnames';
 import debounce from 'lodash.debounce';
-import { useEffect, useMemo, useState } from 'react';
+import { CartItemOptions } from '../cart-item-options/cart-item-options';
 
 import styles from './cart-item.module.scss';
-
-const MAX_OPTIONS_VISIBLE = 1;
 
 export interface CartItemProps {
     item: cart.LineItem;
@@ -30,7 +29,6 @@ export const CartItem = ({
     const productName = item.productName?.translated ?? '';
 
     const [quantity, setQuantity] = useState(item.quantity!);
-    const [moreOptionsExpanded, setMoreOptionsExpanded] = useState(false);
 
     useEffect(() => {
         if (!isUpdating) {
@@ -79,32 +77,11 @@ export const CartItem = ({
                         )}
 
                         {item.descriptionLines && item.descriptionLines.length > 0 && (
-                            <div className={styles.options}>
-                                {item.descriptionLines
-                                    .slice(0, moreOptionsExpanded ? undefined : MAX_OPTIONS_VISIBLE)
-                                    .map((option) => (
-                                        <div key={option.name!.translated} className="paragraph3">
-                                            {option.name!.translated}:{' '}
-                                            {option.colorInfo
-                                                ? option.colorInfo.translated
-                                                : option.plainText?.translated}
-                                        </div>
-                                    ))}
-
-                                {item.descriptionLines.length > MAX_OPTIONS_VISIBLE && (
-                                    <button
-                                        className={styles.moreOptionsButton}
-                                        onClick={() => setMoreOptionsExpanded((p) => !p)}
-                                    >
-                                        {moreOptionsExpanded ? 'Less Details' : 'More Details'}
-                                        <DropdownIcon
-                                            className={classNames(styles.moreOptionsIcon, {
-                                                [styles.rotated]: moreOptionsExpanded,
-                                            })}
-                                        />
-                                    </button>
-                                )}
-                            </div>
+                            <CartItemOptions
+                                className={styles.options}
+                                options={item.descriptionLines}
+                                visibleOptionsCount={1}
+                            />
                         )}
                     </div>
 

--- a/src/components/cart/cart-item/cart-item.tsx
+++ b/src/components/cart/cart-item/cart-item.tsx
@@ -1,14 +1,16 @@
 import { cart } from '@wix/ecom';
 import { media } from '@wix/sdk';
 import { QuantityInput } from '~/components/quantity-input/quantity-input';
-import { TrashIcon, ImagePlaceholderIcon, ErrorIcon } from '~/components/icons';
+import { TrashIcon, ImagePlaceholderIcon, ErrorIcon, DropdownIcon } from '~/components/icons';
+import { Spinner } from '~/components/spinner/spinner';
+import { ProductPrice } from '~/components/product-price/product-price';
 import classNames from 'classnames';
 import debounce from 'lodash.debounce';
 import { useEffect, useMemo, useState } from 'react';
 
 import styles from './cart-item.module.scss';
-import { Spinner } from '~/components/spinner/spinner';
-import { ProductPrice } from '~/components/product-price/product-price';
+
+const MAX_OPTIONS_VISIBLE = 1;
 
 export interface CartItemProps {
     item: cart.LineItem;
@@ -28,6 +30,7 @@ export const CartItem = ({
     const productName = item.productName?.translated ?? '';
 
     const [quantity, setQuantity] = useState(item.quantity!);
+    const [moreOptionsExpanded, setMoreOptionsExpanded] = useState(false);
 
     useEffect(() => {
         if (!isUpdating) {
@@ -67,11 +70,44 @@ export const CartItem = ({
                 <div className={styles.productInfo}>
                     <div className={styles.productNameAndPrice}>
                         <div className={styles.productName}>{productName}</div>
+
                         {item.fullPrice?.formattedConvertedAmount && (
                             <ProductPrice
                                 price={item.fullPrice?.formattedConvertedAmount}
                                 discountedPrice={item.price?.formattedConvertedAmount}
                             />
+                        )}
+
+                        {item.descriptionLines && item.descriptionLines.length > 0 && (
+                            <div className={styles.options}>
+                                {item.descriptionLines
+                                    .slice(0, moreOptionsExpanded ? undefined : MAX_OPTIONS_VISIBLE)
+                                    .map((option) => (
+                                        <div key={option.name!.translated} className="paragraph3">
+                                            {option.name!.translated}:{' '}
+                                            {option.colorInfo
+                                                ? option.colorInfo.translated
+                                                : option.plainText?.translated}
+                                        </div>
+                                    ))}
+
+                                {item.descriptionLines.length > MAX_OPTIONS_VISIBLE && (
+                                    <button
+                                        className={styles.moreOptionsButton}
+                                        onClick={() => setMoreOptionsExpanded((p) => !p)}
+                                    >
+                                        {moreOptionsExpanded ? 'Less Details' : 'More Details'}
+                                        <DropdownIcon
+                                            width={12}
+                                            style={
+                                                moreOptionsExpanded
+                                                    ? { transform: 'rotate(180deg)' }
+                                                    : undefined
+                                            }
+                                        />
+                                    </button>
+                                )}
+                            </div>
                         )}
                     </div>
 

--- a/src/components/cart/cart-item/cart-item.tsx
+++ b/src/components/cart/cart-item/cart-item.tsx
@@ -98,12 +98,9 @@ export const CartItem = ({
                                     >
                                         {moreOptionsExpanded ? 'Less Details' : 'More Details'}
                                         <DropdownIcon
-                                            width={12}
-                                            style={
-                                                moreOptionsExpanded
-                                                    ? { transform: 'rotate(180deg)' }
-                                                    : undefined
-                                            }
+                                            className={classNames(styles.moreOptionsIcon, {
+                                                [styles.rotated]: moreOptionsExpanded,
+                                            })}
                                         />
                                     </button>
                                 )}


### PR DESCRIPTION
Show product options in cart. By default only 1 option is visible. A user can expand all of them using "More Details" button.

<img width="400" alt="Screenshot 2024-10-15 at 18 48 46" src="https://github.com/user-attachments/assets/2d1a1219-c413-4977-a0fe-de7a40cef423">
<img width="400" alt="Screenshot 2024-10-15 at 18 48 51" src="https://github.com/user-attachments/assets/5013b04e-851e-40cf-833b-a25884270585">
