### PR TITLE
feat: non-visible and out of stock variants

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -27,6 +27,7 @@ import { getErrorMessage, removeQueryStringFromUrl } from '~/utils';
 import {
     getMedia,
     getPriceData,
+    getProductOptions,
     getSelectedVariant,
     getSKU,
     isOutOfStock,
@@ -108,6 +109,7 @@ export default function ProductDetailsPage() {
     const priceData = getPriceData(product, selectedChoices);
     const sku = getSKU(product, selectedChoices);
     const media = getMedia(product, selectedChoices);
+    const productOptions = getProductOptions(product, selectedChoices);
 
     const handleAddToCartClick = () => {
         setAddToCartAttempted(true);
@@ -167,9 +169,9 @@ export default function ProductDetailsPage() {
                         />
                     )}
 
-                    {product.productOptions && product.productOptions.length > 0 && (
+                    {productOptions && productOptions.length > 0 && (
                         <div className={styles.productOptions}>
-                            {product.productOptions.map((option) => (
+                            {productOptions.map((option) => (
                                 <ProductOption
                                     key={option.name}
                                     error={

--- a/src/components/color-select/color-select.module.scss
+++ b/src/components/color-select/color-select.module.scss
@@ -49,3 +49,26 @@
 .root.hasError .option {
     border-color: var(--border-color-error);
 }
+
+.crossedOut {
+    position: relative;
+    overflow: hidden;
+}
+
+.crossedOut::after {
+    content: '';
+    position: absolute;
+    height: 1px;
+    transform: rotate(-45deg);
+    inset: -50%;
+    margin: auto;
+    border-top: 1px solid var(--border-color);
+}
+
+.crossedOut:hover::after {
+    border-color: var(--border-color-hover);
+}
+
+.crossedOut.selected::after {
+    border-color: var(--border-color-selected);
+}

--- a/src/components/color-select/color-select.tsx
+++ b/src/components/color-select/color-select.tsx
@@ -5,6 +5,7 @@ import styles from './color-select.module.scss';
 export interface ColorSelectOption {
     id: string;
     color: string;
+    crossedOut?: boolean;
 }
 
 export interface ColorSelectProps {
@@ -29,6 +30,7 @@ export const ColorSelect = ({
                     key={option.id}
                     className={classNames(styles.option, {
                         [styles.selected]: selectedId === option.id,
+                        [styles.crossedOut]: option.crossedOut,
                     })}
                     onClick={() => onChange(option.id)}
                 >

--- a/src/components/product-option/product-option.tsx
+++ b/src/components/product-option/product-option.tsx
@@ -41,7 +41,13 @@ export const ProductOption = ({ option, selectedChoice, error, onChange }: Produ
                     className="colorSelect"
                     // `description` is what identifies the color choice. It's the unique color name.
                     // `value` is the color value, which can be repeated in different color choices.
-                    options={choices.map((c) => ({ id: c.description!, color: c.value! }))}
+                    options={choices
+                        .filter((c) => c.value && c.description && c.visible)
+                        .map((c) => ({
+                            id: c.description!,
+                            color: c.value!,
+                            crossedOut: !c.inStock,
+                        }))}
                     selectedId={selectedChoice?.description ?? ''}
                     onChange={handleChange}
                     hasError={hasError}
@@ -53,11 +59,14 @@ export const ProductOption = ({ option, selectedChoice, error, onChange }: Produ
                     onValueChange={handleChange}
                     hasError={hasError}
                 >
-                    {choices.map((c) => (
-                        <SelectItem key={c.value} value={c.value!}>
-                            {c.description}
-                        </SelectItem>
-                    ))}
+                    {choices
+                        .filter((c) => c.value && c.description && c.visible)
+                        .map((c) => (
+                            <SelectItem key={c.value} value={c.value!}>
+                                {c.description}
+                                {!c.inStock && ` (out of stock)`}
+                            </SelectItem>
+                        ))}
                 </Select>
             )}
 


### PR DESCRIPTION
Copy https://github.com/codux-templates/e-commerce-remix/pull/89

Differences:
- styles
- components usage
- `crossedOut` instead of `inStock` for color select option to keep `ColorSelect` component generic.

<img width="1388" alt="Screenshot 2024-10-16 at 12 36 15" src="https://github.com/user-attachments/assets/989d888e-dae4-4afd-81fd-c583c9a8cbc0">
