### PR TITLE
fix(ecom-api): make error message required in ecom api failure response

### DIFF
--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -29,7 +29,7 @@ export enum EcomApiErrorCodes {
     GetOrderFailure = 'GetOrderFailure',
 }
 
-export type EcomAPIError = { code: EcomApiErrorCodes; message?: string };
+export type EcomAPIError = { code: EcomApiErrorCodes; message: string };
 export type EcomAPISuccessResponse<T> = { status: 'success'; body: T };
 export type EcomAPIFailureResponse = { status: 'failure'; error: EcomAPIError };
 export type EcomAPIResponse<T> = EcomAPISuccessResponse<T> | EcomAPIFailureResponse;


### PR DESCRIPTION
When returning a failure response from Ecom API, we were sometimes discarding the error message. I've made the error message mandatory, and fixed the cases where it was discarded.