### PR TITLE
fix: Make ComponentWrapper not dependent on ROUTES object

### DIFF
--- a/_codux/board-wrappers/component-wrapper.tsx
+++ b/_codux/board-wrappers/component-wrapper.tsx
@@ -1,7 +1,6 @@
 import { createRemixStub } from '@remix-run/testing';
 import { PropsWithChildren } from 'react';
 import { EcomAPIContextProvider } from '~/lib/ecom';
-import { ROUTES } from '~/src/router/config';
 
 export interface ComponentWrapperProps extends PropsWithChildren {
     loaderData?: Record<string, unknown>;
@@ -11,7 +10,7 @@ export default function ComponentWrapper({ children, loaderData }: ComponentWrap
     const RemixStub = createRemixStub([
         {
             Component: () => children,
-            children: Object.values(ROUTES).map(({ path }) => ({ path })),
+            ErrorBoundary: () => children,
         },
     ]);
 


### PR DESCRIPTION
Render wrapped component as an error boundary of the stubbed Remix app. 
In such case if stubbed Remix app will navigate to non-existing path root ErrorBoundary will be triggered... which will render the same UI (wrapped by the `ComponentWrapper`) so the user won't notice a difference :)