### PR TITLE
fix: featured products fallback didn't work

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -62,7 +62,7 @@ export default function HomePage() {
 
             <FeaturedProductsSection
                 className="alternateBackground"
-                categorySlug="new-inn"
+                categorySlug="new-in"
                 title="New In"
                 description="Embrace a sustainable lifestyle with our newest drop-ins."
             />

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -62,7 +62,7 @@ export default function HomePage() {
 
             <FeaturedProductsSection
                 className="alternateBackground"
-                categorySlug="new-in"
+                categorySlug="new-inn"
                 title="New In"
                 description="Embrace a sustainable lifestyle with our newest drop-ins."
             />

--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -2,7 +2,7 @@ import { collections } from '@wix/stores';
 import { Product } from '@wix/stores_products';
 import classNames from 'classnames';
 import useSWR from 'swr';
-import { getEcomApi, CollectionDetails, isEcomSDKError } from '~/lib/ecom';
+import { getEcomApi, CollectionDetails, EcomApiErrorCodes } from '~/lib/ecom';
 import { FadeIn, Reveal } from '~/lib/components/visual-effects';
 import { ProductCard, ProductCardSkeleton } from '~/src/components/product-card/product-card';
 import { ProductLink } from '~/src/components/product-link/product-link';
@@ -26,7 +26,7 @@ const getFeaturedProducts = async (
         category = response.body;
     } else {
         const error = response.error;
-        if (isEcomSDKError(error) && error.details.applicationError.code === 404) {
+        if (error.code === EcomApiErrorCodes.CategoryNotFound) {
             const response = await api.getCategoryBySlug('all-products');
             if (response.status === 'success') {
                 category = response.body;


### PR DESCRIPTION
If category doesn't exists, fetch data from 'all-products' category.

<img width="1066" alt="Screenshot 2024-10-29 at 12 55 20" src="https://github.com/user-attachments/assets/07115aac-e40a-4b72-a895-67997a107a18">
