### PR TITLE
fix(sass): revert to 1.79.x to avoid import warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "prettier": "^3.3.3",
-        "sass": "^1.80.4",
+        "sass": "~1.79.6",
         "typescript": "~5.6.3",
         "vite": "^5.4.10",
         "vite-tsconfig-paths": "^5.0.1"
@@ -11608,9 +11608,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.80.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.4.tgz",
-      "integrity": "sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==",
+      "version": "1.79.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.6.tgz",
+      "integrity": "sha512-PVVjeeiUGx6Nj4PtEE/ecwu8ltwfPKzHxbbVmmLj4l1FYHhOyfA0scuVF8sVaa+b+VY4z7BVKjKq0cPUQdUU3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "prettier": "^3.3.3",
-    "sass": "^1.80.4",
+    "sass": "~1.79.6",
     "typescript": "~5.6.3",
     "vite": "^5.4.10",
     "vite-tsconfig-paths": "^5.0.1"


### PR DESCRIPTION
new version prints a warning for every transpiled file. could be seen during `npm run build/dev`