### PR TITLE
refactor: product fetching

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -33,7 +33,7 @@ export const getStaticRoutes: GetStaticRoutes = async () => {
         throw products.error;
     }
 
-    return products.body.map((product) => `/product-details/${product.slug}`);
+    return products.body.items.map((product) => `/product-details/${product.slug}`);
 };
 
 interface ProductDetailsLocationState {

--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -79,7 +79,8 @@ export enum ProductSortBy {
     nameDesc = 'nameDesc',
 }
 
-interface GetProductsByCategoryOptions {
+interface GetProductsOptions {
+    categorySlug?: string;
     skip?: number;
     limit?: number;
     filters?: IProductFilters;
@@ -91,10 +92,8 @@ export type AddToCartOptions =
     | { options: Record<string, string | undefined> };
 
 export type EcomAPI = {
-    getProducts: (limit?: number) => Promise<EcomAPIResponse<Product[]>>;
-    getProductsByCategory: (
-        categorySlug: string,
-        options?: GetProductsByCategoryOptions,
+    getProducts: (
+        options?: GetProductsOptions,
     ) => Promise<EcomAPIResponse<{ items: Product[]; totalCount: number }>>;
     getFeaturedProducts: (
         categorySlug: string,

--- a/lib/route-loaders/products.ts
+++ b/lib/route-loaders/products.ts
@@ -17,7 +17,8 @@ export async function getProductsRouteData(
         productPriceBoundsResponse,
     ] = await Promise.all([
         api.getCategoryBySlug(categorySlug),
-        api.getProductsByCategory(categorySlug, {
+        api.getProducts({
+            categorySlug,
             filters: productFiltersFromSearchParams(searchParams),
             sortBy: productSortByFromSearchParams(searchParams),
         }),


### PR DESCRIPTION
We have four function for fetching products:

* getProducts
* getProductsByCategory
* getPromotedProducts (identical to getProducts but with hardcoded limit 4)
* getFeaturedProducts (similar to getProductsByCategory, but with fallback on `all-products`)

I think we need to organize and simplify this a little. In this PR, I've started with removing `getProductsByCategory`, and replacing it with `getProducts({ categorySlug })`.

Also made a couple of tweaks to `useProductsPageResults()` that should not affect the behavior.
