### PR TITLE
refactor: functions for ecom api initialization

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -2,8 +2,8 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
 import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
 import type { GetStaticRoutes } from '@wixc3/define-remix-app';
 import classNames from 'classnames';
-import { createApi, createWixClient, EcomApiErrorCodes } from '~/lib/ecom';
-import { initializeEcomApi } from '~/lib/ecom/session';
+import { EcomApiErrorCodes, initializeEcomApiAnonymous } from '~/lib/ecom';
+import { initializeEcomApiForRequest } from '~/lib/ecom/session';
 import { useProductDetails } from '~/lib/hooks';
 import { getProductDetailsRouteData } from '~/lib/route-loaders';
 import { getErrorMessage } from '~/lib/utils';
@@ -20,13 +20,13 @@ import { ShareProductLinks } from '~/src/components/share-product-links/share-pr
 import styles from './route.module.scss';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
-    const api = await initializeEcomApi(request);
+    const api = await initializeEcomApiForRequest(request);
 
     return getProductDetailsRouteData(api, params.productSlug, request.url);
 };
 
 export const getStaticRoutes: GetStaticRoutes = async () => {
-    const api = createApi(createWixClient());
+    const api = initializeEcomApiAnonymous();
     const products = await api.getProducts();
 
     if (products.status === 'failure') {

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -3,8 +3,8 @@ import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from 
 import type { GetStaticRoutes } from '@wixc3/define-remix-app';
 import classNames from 'classnames';
 import { FadeIn } from '~/lib/components/visual-effects';
-import { createApi, createWixClient, EcomApiErrorCodes } from '~/lib/ecom';
-import { initializeEcomApi } from '~/lib/ecom/session';
+import { EcomApiErrorCodes, initializeEcomApiAnonymous } from '~/lib/ecom';
+import { initializeEcomApiForRequest } from '~/lib/ecom/session';
 import { useAppliedProductFilters } from '~/lib/hooks';
 import { useProductSorting } from '~/lib/hooks/use-product-sorting';
 import { useProductsPageResults } from '~/lib/hooks/use-products-page-results';
@@ -24,7 +24,7 @@ import { ProductSortingSelect } from '~/src/components/product-sorting-select/pr
 import styles from './route.module.scss';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
-    const api = await initializeEcomApi(request);
+    const api = await initializeEcomApiForRequest(request);
     return getProductsRouteData(api, params.categorySlug, request.url);
 };
 
@@ -36,7 +36,7 @@ const breadcrumbs: RouteBreadcrumbs<typeof loader> = (match) => [
 ];
 
 export const getStaticRoutes: GetStaticRoutes = async () => {
-    const api = createApi(createWixClient());
+    const api = initializeEcomApiAnonymous();
     const categories = await api.getAllCategories();
 
     if (categories.status === 'failure') {

--- a/app/routes/thank-you/route.tsx
+++ b/app/routes/thank-you/route.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
-import { initializeEcomApi } from '~/lib/ecom/session';
+import { initializeEcomApiForRequest } from '~/lib/ecom/session';
 import { getThankYouRouteData } from '~/lib/route-loaders';
 import { getErrorMessage } from '~/lib/utils';
 import { CategoryLink } from '~/src/components/category-link/category-link';
@@ -10,7 +10,7 @@ import { OrderSummary } from '~/src/components/order-summary/order-summary';
 import styles from './route.module.scss';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const api = await initializeEcomApi(request);
+    const api = await initializeEcomApiForRequest(request);
 
     return getThankYouRouteData(api, request.url);
 };

--- a/lib/ecom/api-context.tsx
+++ b/lib/ecom/api-context.tsx
@@ -1,7 +1,7 @@
 import { Tokens } from '@wix/sdk';
 import React, { FC, useMemo } from 'react';
 import { SWRConfig } from 'swr';
-import { createApi, createWixClient } from './api';
+import { initializeEcomApiAnonymous, initializeEcomApiWithTokens } from './api';
 import { EcomAPI } from './types';
 
 export const EcomAPIContext = React.createContext<EcomAPI | null>(null);
@@ -20,8 +20,7 @@ export interface EcomAPIContextProviderProps extends React.PropsWithChildren {
 
 export const EcomAPIContextProvider: FC<EcomAPIContextProviderProps> = ({ tokens, children }) => {
     const api = useMemo(() => {
-        const client = createWixClient(tokens);
-        return createApi(client);
+        return tokens ? initializeEcomApiWithTokens(tokens) : initializeEcomApiAnonymous();
     }, [tokens]);
 
     return (

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -69,7 +69,7 @@ export function initializeEcomApiAnonymous() {
     return createEcomApi(client);
 }
 
-export function createEcomApi(wixClient: WixApiClient): EcomAPI {
+function createEcomApi(wixClient: WixApiClient): EcomAPI {
     return {
         async getProducts({ categorySlug, skip = 0, limit = 100, filters, sortBy } = {}) {
             try {

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -59,7 +59,17 @@ export function createWixClient(tokens?: Tokens): WixApiClient {
     });
 }
 
-export function createApi(wixClient: WixApiClient): EcomAPI {
+export function initializeEcomApiWithTokens(tokens: Tokens) {
+    const client = createWixClient(tokens);
+    return createEcomApi(client);
+}
+
+export function initializeEcomApiAnonymous() {
+    const client = createWixClient();
+    return createEcomApi(client);
+}
+
+export function createEcomApi(wixClient: WixApiClient): EcomAPI {
     return {
         async getProducts({ categorySlug, skip = 0, limit = 100, filters, sortBy } = {}) {
             try {

--- a/lib/ecom/session.ts
+++ b/lib/ecom/session.ts
@@ -1,6 +1,6 @@
 import { createCookieSessionStorage } from '@remix-run/node';
 import { Tokens } from '@wix/sdk';
-import { createApi, createWixClient, getWixClientId } from './api';
+import { createEcomApi, createWixClient, getWixClientId } from './api';
 
 export type SessionData = {
     wixEcomTokens: Tokens;
@@ -43,9 +43,9 @@ export async function initializeEcomSession(request: Request) {
     return { wixEcomTokens, session, shouldUpdateSessionCookie };
 }
 
-export async function initializeEcomApi(request: Request) {
+export async function initializeEcomApiForRequest(request: Request) {
     const { session } = await initializeEcomSession(request);
     const tokens = session.get('wixEcomTokens');
     const client = createWixClient(tokens);
-    return createApi(client);
+    return createEcomApi(client);
 }

--- a/lib/ecom/session.ts
+++ b/lib/ecom/session.ts
@@ -1,6 +1,11 @@
 import { createCookieSessionStorage } from '@remix-run/node';
 import { Tokens } from '@wix/sdk';
-import { createEcomApi, createWixClient, getWixClientId } from './api';
+import {
+    createWixClient,
+    getWixClientId,
+    initializeEcomApiAnonymous,
+    initializeEcomApiWithTokens,
+} from './api';
 
 export type SessionData = {
     wixEcomTokens: Tokens;
@@ -46,6 +51,5 @@ export async function initializeEcomSession(request: Request) {
 export async function initializeEcomApiForRequest(request: Request) {
     const { session } = await initializeEcomSession(request);
     const tokens = session.get('wixEcomTokens');
-    const client = createWixClient(tokens);
-    return createEcomApi(client);
+    return tokens ? initializeEcomApiWithTokens(tokens) : initializeEcomApiAnonymous();
 }


### PR DESCRIPTION
We use several ways to get an instance of EcomAPI:

1. `initializeEcomApi(request)`
2. `createApi(createWixClient(tokens))`
3. `createApi(createWixClient())`

To unify them and to make it explicit when we're creating an anonymous instance that doesn't have a client token, I've changed these as follows:

1. `initializeEcomApiForRequest()`
2. `initializeEcomApiWithTokens()`
3. `initializeEcomApiAnonymous()`

Also made the function `createApi()` private.