### PR TITLE
refactor: remove getPromotedProducts function

### DIFF
--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -124,14 +124,6 @@ function createEcomApi(wixClient: WixApiClient): EcomAPI {
             if (productsResponse.status === 'failure') throw productsResponse.error;
             return successResponse({ category, items: productsResponse.body.items });
         },
-        async getPromotedProducts() {
-            try {
-                const products = (await wixClient.products.queryProducts().limit(4).find()).items;
-                return successResponse(products);
-            } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
-            }
-        },
         async getProductBySlug(slug) {
             try {
                 const product = (

--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -99,7 +99,6 @@ export type EcomAPI = {
         categorySlug: string,
         count: number,
     ) => Promise<EcomAPIResponse<{ category: Collection; items: Product[] }>>;
-    getPromotedProducts: () => Promise<EcomAPIResponse<Product[]>>;
     getProductBySlug: (slug: string) => Promise<EcomAPIResponse<Product>>;
     getCart: () => Promise<EcomAPIResponse<Cart>>;
     getCartTotals: () => Promise<EcomAPIResponse<CartTotals>>;


### PR DESCRIPTION
Wix Ecom doesn't have a concept of promoted products, our function `api.getPromotedProducts()` simply returns 4 products from the store in unspecified order.

This function is used only in `e-commerce-remix` template, I've removed it from the API, it should be replaced with `api.getProducts({ limit: 4 })`