### PR TITLE
feat: remove fallback to all products in featured products section

### DIFF
--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -7,7 +7,6 @@ import { DEMO_STORE_WIX_CLIENT_ID, WIX_STORES_APP_ID } from './constants';
 import { getFilteredProductsQuery } from './product-filters';
 import { getSortedProductsQuery } from './product-sorting';
 import {
-    CollectionDetails,
     EcomAPI,
     EcomApiErrorCodes,
     EcomAPIFailureResponse,
@@ -97,32 +96,6 @@ function createEcomApi(wixClient: WixApiClient): EcomAPI {
             } catch (e) {
                 return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
             }
-        },
-        async getFeaturedProducts(categorySlug, count) {
-            let category: CollectionDetails | undefined;
-            const response = await this.getCategoryBySlug(categorySlug);
-            if (response.status === 'success') {
-                category = response.body;
-            } else {
-                const error = response.error;
-                if (error.code === EcomApiErrorCodes.CategoryNotFound) {
-                    const response = await this.getCategoryBySlug('all-products');
-                    if (response.status === 'success') {
-                        category = response.body;
-                    } else {
-                        throw error;
-                    }
-                } else {
-                    throw error;
-                }
-            }
-
-            const productsResponse = await this.getProducts({
-                categorySlug: category.slug!,
-                limit: count,
-            });
-            if (productsResponse.status === 'failure') throw productsResponse.error;
-            return successResponse({ category, items: productsResponse.body.items });
         },
         async getProductBySlug(slug) {
             try {

--- a/lib/ecom/hooks.ts
+++ b/lib/ecom/hooks.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import useSwr, { Key } from 'swr';
+import useSwr, { Key, SWRResponse } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { findItemIdInCart } from '~/lib/utils';
 import { useEcomAPI } from './api-context';
-import { AddToCartOptions } from './types';
+import { AddToCartOptions, CollectionDetails, GetProductsOptions, Product } from './types';
 
 export const useCartData = () => {
     const ecomApi = useEcomAPI();
@@ -169,3 +169,39 @@ export const useCart = () => {
         checkout,
     };
 };
+
+export function useCategoryDetails(slug: string): SWRResponse<CollectionDetails> {
+    const ecomApi = useEcomAPI();
+    return useSwr(
+        ['category-details', slug],
+        async ([, slug]) => {
+            const response = await ecomApi.getCategoryBySlug(slug);
+            if (response.status === 'failure') throw response.error;
+            return response.body;
+        },
+        {
+            keepPreviousData: false,
+            revalidateOnFocus: false,
+            shouldRetryOnError: false,
+        },
+    );
+}
+
+export function useProducts(
+    options: GetProductsOptions,
+): SWRResponse<{ items: Product[]; totalCount: number }> {
+    const ecomApi = useEcomAPI();
+    return useSwr(
+        ['products', options],
+        async ([, options]) => {
+            const response = await ecomApi.getProducts(options);
+            if (response.status === 'failure') throw response.error;
+            return response.body;
+        },
+        {
+            keepPreviousData: false,
+            revalidateOnFocus: false,
+            shouldRetryOnError: false,
+        },
+    );
+}

--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -79,7 +79,7 @@ export enum ProductSortBy {
     nameDesc = 'nameDesc',
 }
 
-interface GetProductsOptions {
+export interface GetProductsOptions {
     categorySlug?: string;
     skip?: number;
     limit?: number;
@@ -95,10 +95,6 @@ export type EcomAPI = {
     getProducts: (
         options?: GetProductsOptions,
     ) => Promise<EcomAPIResponse<{ items: Product[]; totalCount: number }>>;
-    getFeaturedProducts: (
-        categorySlug: string,
-        count: number,
-    ) => Promise<EcomAPIResponse<{ category: Collection; items: Product[] }>>;
     getProductBySlug: (slug: string) => Promise<EcomAPIResponse<Product>>;
     getCart: () => Promise<EcomAPIResponse<Cart>>;
     getCartTotals: () => Promise<EcomAPIResponse<CartTotals>>;

--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import useSWR from 'swr';
 import { FadeIn, Reveal } from '~/lib/components/visual-effects';
-import { useEcomAPI } from '~/lib/ecom';
+import { useCategoryDetails, useProducts } from '~/lib/ecom';
 import { ProductCard, ProductCardSkeleton } from '~/src/components/product-card/product-card';
 import { ProductLink } from '~/src/components/product-link/product-link';
 
@@ -17,32 +16,22 @@ interface FeaturedProductsSectionProps {
 
 export const FeaturedProductsSection = (props: FeaturedProductsSectionProps) => {
     const { title, description, productCount = 4, categorySlug, className } = props;
-
-    const api = useEcomAPI();
-
-    const { data } = useSWR(
-        `/category/${categorySlug}/featured/limit/${productCount}`,
-        async () => {
-            const response = await api.getFeaturedProducts(categorySlug, productCount);
-            if (response.status === 'failure') {
-                throw response.error;
-            }
-
-            return response.body;
-        },
-    );
+    const category = useCategoryDetails(categorySlug);
+    const products = useProducts({ categorySlug, limit: productCount });
 
     return (
         <div className={classNames(styles.root, className)}>
             <FadeIn className={styles.header} duration={1.8}>
-                <h3 className={styles.headerTitle}>{title ?? data?.category.name}</h3>
+                <h3 className={styles.headerTitle}>
+                    {title ?? category.data?.name ?? categorySlug}
+                </h3>
                 <div className={styles.headerDescription}>
-                    {description ?? data?.category.description}
+                    {description ?? category.data?.description}
                 </div>
             </FadeIn>
             <Reveal className={styles.productsRow} direction="down" duration={1.4}>
-                {data
-                    ? data.items.map((product) => (
+                {products.data
+                    ? products.data.items.map((product) => (
                           <ProductLink key={product._id} productSlug={product.slug!}>
                               <ProductCard
                                   name={product.name!}


### PR DESCRIPTION
Since we now have skeletons in the `<FeaturedProductsSection>`, showing them if the category doesn’t exist seems better than falling back on all products. This makes it easier for users to understand that something isn't working, while still giving them an idea of what this section should display.

This change also allowed to remove `.getFeaturedProducts()` from the `EcomAPI`, simplify the `FeaturedProductsSection` component by removing `useSWR` from it, and reduce the overall amount of code a little.

---

Skeletons:

<img width="695" alt="Screenshot 2024-10-30 at 14 35 17" src="https://github.com/user-attachments/assets/85ec3966-52ec-453a-9e11-6f9692a6138b">
