### PR TITLE
fix: Add class name to the About Us menu item

### DIFF
--- a/src/components/navigation-menu/navigation-menu.tsx
+++ b/src/components/navigation-menu/navigation-menu.tsx
@@ -38,7 +38,9 @@ export const NavigationMenu = ({ className, vertical = false }: NavigationMenuPr
                     </CategoryLink>
                 </li>
                 <li>
-                    <NavLink to="/about-us">About Us</NavLink>
+                    <NavLink to="/about-us" className={menuItemStyle}>
+                        About Us
+                    </NavLink>
                 </li>
             </ul>
         </nav>


### PR DESCRIPTION
The className prop was lost in the [removing routes config PR](https://github.com/codux-templates/e-commerce-reclaim/pull/167).