### PR TITLE
infra: tweak .eslintrc

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,7 +34,7 @@ module.exports = {
 
         // React
         {
-            files: ['**/*.{js,jsx,ts,tsx}'],
+            files: ['**/*.{ts,tsx}'],
             plugins: ['react', 'jsx-a11y'],
             extends: [
                 'plugin:react/recommended',
@@ -56,12 +56,9 @@ module.exports = {
                 },
             },
             rules: {
+                'react/jsx-no-target-blank': 'off',
                 'jsx-a11y/click-events-have-key-events': 'off',
                 'jsx-a11y/no-static-element-interactions': 'off',
-                'import/no-extraneous-dependencies': [
-                    'error',
-                    { devDependencies: ['_codux/**/*'] },
-                ],
             },
         },
 
@@ -88,7 +85,7 @@ module.exports = {
             ],
             rules: {
                 '@typescript-eslint/no-explicit-any': 'off',
-                'react/jsx-no-target-blank': 'off',
+                '@typescript-eslint/explicit-member-accessibility': 'error',
                 'import/no-extraneous-dependencies': [
                     'error',
                     { devDependencies: ['_codux/**/*', 'vite.config.ts'] },


### PR DESCRIPTION
1. `react/jsx-no-target-blank` belongs in the React section rather than the TypeScript section.
2. `import/no-extraneous-dependencies` is redundant in the React section, since it's already specified in the TypeScript section and we're not using `js/jsx` in this project.
3. Added `@typescript-eslint/explicit-member-accessibility`