### PR TITLE
refactor: automatically normalize WixClient errors

### DIFF
--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -12,7 +12,7 @@ import {
     EcomApiFailureResponse,
     EcomApiSuccessResponse,
 } from './types';
-import { isNotFoundWixClientError, throwNormalizedWixClientError } from './wix-client-error';
+import { isNotFoundWixClientError, normalizeWixClientError } from './wix-client-error';
 
 type WixApiClient = WixClient<
     undefined,
@@ -292,10 +292,12 @@ const withNormalizedWixClientErrors = (api: EcomApi): EcomApi => {
             try {
                 const result = Reflect.apply(original, api, args);
                 if (result instanceof Promise) {
-                    return result.catch(throwNormalizedWixClientError);
+                    return result.catch((error) => {
+                        throw normalizeWixClientError(error);
+                    });
                 }
             } catch (error) {
-                throwNormalizedWixClientError(error);
+                throw normalizeWixClientError(error);
             }
         });
     }

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -68,14 +68,12 @@ export function initializeEcomApiAnonymous() {
     return createEcomApi(client);
 }
 
-function createEcomApi(wixClient: WixApiClient): EcomApi {
-    return {
+const createEcomApi = (wixClient: WixApiClient): EcomApi =>
+    withNormalizedWixClientErrors({
         async getProducts({ categorySlug, skip = 0, limit = 100, filters, sortBy } = {}) {
             try {
                 const { collection } = categorySlug
-                    ? await wixClient.collections
-                          .getCollectionBySlug(categorySlug)
-                          .catch(throwNormalizedWixClientError)
+                    ? await wixClient.collections.getCollectionBySlug(categorySlug)
                     : {};
 
                 let query = wixClient.products.queryProducts();
@@ -92,12 +90,7 @@ function createEcomApi(wixClient: WixApiClient): EcomApi {
                     query = getSortedProductsQuery(query, sortBy);
                 }
 
-                const { items, totalCount = 0 } = await query
-                    .skip(skip)
-                    .limit(limit)
-                    .find()
-                    .catch(throwNormalizedWixClientError);
-
+                const { items, totalCount = 0 } = await query.skip(skip).limit(limit).find();
                 return successResponse({ items, totalCount });
             } catch (e) {
                 return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
@@ -256,7 +249,7 @@ function createEcomApi(wixClient: WixApiClient): EcomApi {
 
         async getOrder(id) {
             try {
-                return await wixClient.orders.getOrder(id).catch(throwNormalizedWixClientError);
+                return await wixClient.orders.getOrder(id);
             } catch (error) {
                 if (!isNotFoundWixClientError(error)) throw error;
             }
@@ -285,8 +278,25 @@ function createEcomApi(wixClient: WixApiClient): EcomApi {
                 return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
             }
         },
-    };
-}
+    });
+
+const withNormalizedWixClientErrors = (api: EcomApi): EcomApi => {
+    for (const key of Object.keys(api)) {
+        const original = Reflect.get(api, key);
+        if (typeof original !== 'function') continue;
+        Reflect.set(api, key, (...args: unknown[]) => {
+            try {
+                const result = Reflect.apply(original, api, args);
+                if (result instanceof Promise) {
+                    return result.catch(throwNormalizedWixClientError);
+                }
+            } catch (error) {
+                throwNormalizedWixClientError(error);
+            }
+        });
+    }
+    return api;
+};
 
 function failureResponse(code: EcomApiErrorCodes, message: string): EcomApiFailureResponse {
     return {

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -280,6 +280,10 @@ const createEcomApi = (wixClient: WixApiClient): EcomApi =>
         },
     });
 
+/**
+ * Wraps all methods of the EcomApi with a try-catch block that fixes broken
+ * error messages in WixClient errors and rethrows them.
+ */
 const withNormalizedWixClientErrors = (api: EcomApi): EcomApi => {
     for (const key of Object.keys(api)) {
         const original = Reflect.get(api, key);

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -296,6 +296,7 @@ const withNormalizedWixClientErrors = (api: EcomApi): EcomApi => {
                         throw normalizeWixClientError(error);
                     });
                 }
+                return result;
             } catch (error) {
                 throw normalizeWixClientError(error);
             }

--- a/lib/ecom/wix-client-error.ts
+++ b/lib/ecom/wix-client-error.ts
@@ -79,13 +79,13 @@ export const isNotFoundWixClientError = (error: unknown): boolean => {
 };
 
 /**
- * Fixes the broken error message in a `WixClient` error and rethrows the error.
- * If it is not a `WixClient` error, rethrows it unchanged.
+ * Fixes the broken error message in a `WixClient` error. If it is not a
+ * `WixClient` error, returns it unchanged.
  * @see {@link getWixClientErrorMessage} for details.
  */
-export const throwNormalizedWixClientError = (error: unknown): never => {
+export const normalizeWixClientError = (error: unknown): unknown => {
     if (isWixClientError(error)) {
         error.message = getWixClientErrorMessage(error);
     }
-    throw error;
+    return error;
 };


### PR DESCRIPTION
`WixClient` throws errors with garbled messages, to fix them we have to chain `.catch(throwNormalizedWixClientError)` to each method call of `WixClient` inside of `EcomApi`. This is error-prone.

This PR introduces a helper function that iterates over all methods of `EcomApi` and wraps them with `normalizeWixClientError` automatically. The code is hacky, but it makes `EcomApi` methods nice and clean:

```ts
getCart() {
    return wixClient.currentCart.getCurrentCart();
}
```

Other alternatives:

1. Add a try-catch inside of each `EcomApi` method:
```ts
async getCart() {
    try {
        return await wixClient.currentCart.getCurrentCart();
    } catch (error) {
        throw normalizeWixClientError(error);
    }
}
```

2. Wrap each `EcomApi` method individually:
```ts
getCart: withNormalizedWixClientErrors(() => {
    return wixClient.currentCart.getCurrentCart();
})
```

3. Use experimental decorators (this will require converting `createEcomApi` to a class):
```ts
@normalizeWixClientErrors
getCart() {
   return wixClient.currentCart.getCurrentCart();
}
```

Let me know if you prefer one of the alternatives. The downside is that they require adding something to each method manually, and failing to do so won't have an obvious effect.