### PR TITLE
refactor: spinner improvements

### DIFF
--- a/src/components/spinner/spinner.module.scss
+++ b/src/components/spinner/spinner.module.scss
@@ -1,19 +1,18 @@
 .spinner {
-    animation: rotation 2s linear infinite;
+    animation: spin 2s linear infinite;
 }
 
 .circle {
-    animation: circleAnimation 1.5s ease-in-out infinite;
-    stroke: var(--primary5);
+    animation: pulsingStroke 1.5s ease-in-out infinite;
 }
 
-@keyframes rotation {
+@keyframes spin {
     100% {
         transform: rotate(360deg);
     }
 }
 
-@keyframes circleAnimation {
+@keyframes pulsingStroke {
     0% {
         stroke-dasharray: 1, 150;
         stroke-dashoffset: 0;

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,20 +1,29 @@
+import classNames from 'classnames';
+import { type FC } from 'react';
+
 import styles from './spinner.module.scss';
 
-interface SpinnerProps {
-    size: number;
+interface SpinnerProps extends React.SVGProps<SVGSVGElement> {
+    size: number | string;
 }
 
-export const Spinner = ({ size }: SpinnerProps) => {
-    return (
-        <svg viewBox="0 0 50 50" width={size} height={size} className={styles.spinner}>
-            <circle
-                cx="25"
-                cy="25"
-                r="20"
-                fill="none"
-                strokeWidth="1"
-                className={styles.circle}
-            ></circle>
-        </svg>
-    );
-};
+export const Spinner: FC<SpinnerProps> = ({ className, size, ...props }) => (
+    <svg
+        className={classNames(styles.spinner, className)}
+        viewBox="0 0 50 50"
+        width={size}
+        height={size}
+        {...props}
+    >
+        <circle
+            className={styles.circle}
+            cx="25"
+            cy="25"
+            r="20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1"
+            vectorEffect="non-scaling-stroke"
+        />
+    </svg>
+);


### PR DESCRIPTION
I’d like to use the` <Spinner>` inside a button, but I need a few tweaks:

1. Allow to set the size in units other than pixels: `<Spinner size="1lh" />`.
2. Allow to pass a custom class name.
3. Avoid thinning the stroke at small sizes.
4. Automatically match light-on-dark and dark-on-light text.

https://github.com/user-attachments/assets/0bb665b2-9b91-4995-89aa-190a11a4461b

