### PR TITLE
fix(checkout): propagate correct error message and progress

### DIFF
--- a/app/routes/cart/route.tsx
+++ b/app/routes/cart/route.tsx
@@ -2,8 +2,8 @@ import { CartItem } from '~/src/components/cart/cart-item/cart-item';
 import classNames from 'classnames';
 import { LockIcon } from '~/src/components/icons';
 import { Link } from '@remix-run/react';
-import { useCart } from '~/lib/ecom';
-import { findLineItemPriceBreakdown } from '~/lib/utils';
+import { useCart, useCheckout } from '~/lib/ecom';
+import { findLineItemPriceBreakdown, getErrorMessage } from '~/lib/utils';
 
 import styles from './route.module.scss';
 import { Spinner } from '~/src/components/spinner/spinner';
@@ -15,10 +15,15 @@ export default function CartPage() {
         isCartLoading,
         isCartTotalsUpdating,
         updatingCartItemIds,
-        checkout,
         removeItem,
         updateItemQuantity,
     } = useCart();
+
+    const { checkout, isCheckoutInProgress } = useCheckout({
+        successUrl: '/thank-you',
+        cancelUrl: '/products/all-products',
+        onError: (error) => alert(getErrorMessage(error)),
+    });
 
     if (!cartData && isCartLoading) return null;
 
@@ -90,7 +95,7 @@ export default function CartPage() {
                 <button
                     className={classNames('button', styles.checkoutButton)}
                     onClick={checkout}
-                    disabled={isCartTotalsUpdating}
+                    disabled={isCheckoutInProgress || isCartTotalsUpdating}
                 >
                     Checkout
                 </button>

--- a/app/routes/cart/route.tsx
+++ b/app/routes/cart/route.tsx
@@ -1,12 +1,12 @@
-import { CartItem } from '~/src/components/cart/cart-item/cart-item';
-import classNames from 'classnames';
-import { LockIcon } from '~/src/components/icons';
 import { Link } from '@remix-run/react';
+import classNames from 'classnames';
 import { useCart, useCheckout } from '~/lib/ecom';
 import { findLineItemPriceBreakdown, getErrorMessage } from '~/lib/utils';
+import { CartItem } from '~/src/components/cart/cart-item/cart-item';
+import { LockIcon } from '~/src/components/icons';
+import { Spinner } from '~/src/components/spinner/spinner';
 
 import styles from './route.module.scss';
-import { Spinner } from '~/src/components/spinner/spinner';
 
 export default function CartPage() {
     const {
@@ -97,7 +97,7 @@ export default function CartPage() {
                     onClick={checkout}
                     disabled={isCheckoutInProgress || isCartTotalsUpdating}
                 >
-                    Checkout
+                    {isCheckoutInProgress ? <Spinner size="1lh" /> : 'Checkout'}
                 </button>
 
                 <div className={styles.secureCheckout}>

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -188,35 +188,19 @@ function createEcomApi(wixClient: WixApiClient): EcomApi {
             }
         },
 
-        async checkout() {
-            let checkoutId;
-            try {
-                const result = await wixClient.currentCart.createCheckoutFromCurrentCart({
-                    channelType: currentCart.ChannelType.WEB,
-                });
-                checkoutId = result.checkoutId;
-            } catch (e) {
-                return failureResponse(EcomApiErrorCodes.CreateCheckoutFailure, getErrorMessage(e));
-            }
+        async checkout({ successUrl, cancelUrl }) {
+            const { checkoutId } = await wixClient.currentCart.createCheckoutFromCurrentCart({
+                channelType: currentCart.ChannelType.WEB,
+            });
 
-            try {
-                const { redirectSession } = await wixClient.redirects.createRedirectSession({
-                    ecomCheckout: { checkoutId },
-                    callbacks: {
-                        postFlowUrl: window.location.origin,
-                        thankYouPageUrl: `${window.location.origin}/thank-you`,
-                    },
-                });
-                if (!redirectSession?.fullUrl) {
-                    throw new Error('Missing redirect session url');
-                }
-                return successResponse({ checkoutUrl: redirectSession?.fullUrl });
-            } catch (e) {
-                return failureResponse(
-                    EcomApiErrorCodes.CreateCheckoutRedirectSessionFailure,
-                    getErrorMessage(e),
-                );
-            }
+            const { redirectSession } = await wixClient.redirects.createRedirectSession({
+                ecomCheckout: { checkoutId },
+                callbacks: { postFlowUrl: cancelUrl, thankYouPageUrl: successUrl },
+            });
+
+            const checkoutUrl = redirectSession?.fullUrl;
+            if (!checkoutUrl) throw new Error('Failed to retrieve checkout URL');
+            return { checkoutUrl };
         },
 
         async getAllCategories() {

--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -21,8 +21,6 @@ export enum EcomApiErrorCodes {
     UpdateCartItemQuantityFailure = 'UpdateCartItemQuantityFailure',
     RemoveCartItemFailure = 'RemoveCartItemFailure',
     AddCartItemFailure = 'AddCartItemFailure',
-    CreateCheckoutFailure = 'CreateCheckoutFailure',
-    CreateCheckoutRedirectSessionFailure = 'CreateCheckoutRedirectSessionFailure',
 }
 
 export type EcomApiError = { code: EcomApiErrorCodes; message: string };
@@ -83,7 +81,12 @@ export type EcomApi = {
         quantity: number,
         options?: AddToCartOptions,
     ) => Promise<EcomApiResponse<Cart>>;
-    checkout: () => Promise<EcomApiResponse<{ checkoutUrl: string }>>;
+    checkout: (params: {
+        /** Redirect URL after successful checkout, e.g., 'Thank You' page. */
+        successUrl: string;
+        /** Redirect URL if checkout is cancelled, e.g., 'Browse Products' page. */
+        cancelUrl: string;
+    }) => Promise<{ checkoutUrl: string }>;
     getAllCategories: () => Promise<EcomApiResponse<Collection[]>>;
     getCategoryBySlug: (slug: string) => Promise<EcomApiResponse<CollectionDetails>>;
     getOrder: (id: string) => Promise<OrderDetails | undefined>;

--- a/src/components/cart/cart-view/cart-view.tsx
+++ b/src/components/cart/cart-view/cart-view.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
 import { Cart, CartTotals } from '~/lib/ecom';
-import { findLineItemPriceBreakdown, calculateCartItemsCount } from '~/lib/utils';
+import { calculateCartItemsCount, findLineItemPriceBreakdown } from '~/lib/utils';
 import { CloseIcon, LockIcon } from '~/src/components/icons';
+import { Spinner } from '~/src/components/spinner/spinner';
 import { CartItem } from '../cart-item/cart-item';
 
 import styles from './cart-view.module.scss';
@@ -83,7 +84,7 @@ export const CartView = ({
                             onClick={onCheckout}
                             disabled={isCheckoutInProgress || isUpdating}
                         >
-                            Checkout
+                            {isCheckoutInProgress ? <Spinner size="1lh" /> : 'Checkout'}
                         </button>
                         <button
                             className={classNames('button', styles.viewCartButton)}

--- a/src/components/cart/cart-view/cart-view.tsx
+++ b/src/components/cart/cart-view/cart-view.tsx
@@ -11,6 +11,7 @@ export interface CartViewProps {
     cartTotals?: CartTotals;
     updatingCartItemIds?: string[];
     isUpdating?: boolean;
+    isCheckoutInProgress: boolean;
     onClose: () => void;
     onCheckout: () => void;
     onViewCart: () => void;
@@ -23,6 +24,7 @@ export const CartView = ({
     cartTotals,
     updatingCartItemIds = [],
     isUpdating = false,
+    isCheckoutInProgress,
     onClose,
     onCheckout,
     onViewCart,
@@ -79,7 +81,7 @@ export const CartView = ({
                                 styles.checkoutButton,
                             )}
                             onClick={onCheckout}
-                            disabled={isUpdating}
+                            disabled={isCheckoutInProgress || isUpdating}
                         >
                             Checkout
                         </button>

--- a/src/components/cart/cart.tsx
+++ b/src/components/cart/cart.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from '@remix-run/react';
 import { useCartOpen } from '~/lib/cart-open-context';
-import { useCart } from '~/lib/ecom';
+import { useCart, useCheckout } from '~/lib/ecom';
 import { Drawer } from '~/src/components/drawer/drawer';
 import { CartView } from './cart-view/cart-view';
+import { getErrorMessage } from '~/lib/utils';
 
 export const Cart = () => {
     const { isOpen, setIsOpen } = useCartOpen();
@@ -12,10 +13,15 @@ export const Cart = () => {
         cartTotals,
         isCartTotalsUpdating,
         updatingCartItemIds,
-        checkout,
         removeItem,
         updateItemQuantity,
     } = useCart();
+
+    const { checkout, isCheckoutInProgress } = useCheckout({
+        successUrl: '/thank-you',
+        cancelUrl: '/products/all-products',
+        onError: (error) => alert(getErrorMessage(error)),
+    });
 
     const handleViewCart = () => {
         setIsOpen(false);
@@ -33,6 +39,7 @@ export const Cart = () => {
                 onItemRemove={removeItem}
                 onItemQuantityChange={updateItemQuantity}
                 isUpdating={isCartTotalsUpdating}
+                isCheckoutInProgress={isCheckoutInProgress}
                 updatingCartItemIds={updatingCartItemIds}
             />
         </Drawer>


### PR DESCRIPTION
Fix the following issues:

1. An error message during checkout always displays as "checkout is not configured," regardless of the actual error.
2. After clicking "Checkout", no visual feedback is provided to the user for several seconds, until the redirect to the checkout page completes. I've disabled the button during checkout and added a spinner.
3. The thank you page URL is hardcoded in the `EcomApi`, even though it’s a user-defined route that should be configurable.

I've extracted `useCheckout` out of `useCart` since checkout now has required parameters, and I didn't want to always pass them to `useCart`:

```ts
const { checkout, isCheckoutInProgress } = useCheckout({
    successUrl: '/thank-you',
    cancelUrl: '/all-products',
    onError: (error) => { ... }
});
```

Alternatively I could do it like this:
```ts
const { checkout, isCheckoutInProgress } = useCart();

const handleCheckoutClick = () => {
    void checkout({
        successUrl: '/thank-you',
        cancelUrl: '/all-products',
    }).catch((error) => { ... });
};
```

But it's a bit more unwieldy and it's easier to forget about error handling. I'm not sure which is better.