### PR TITLE
refactor: migrate most of the cart API methods to exceptions

### DIFF
--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -113,22 +113,12 @@ function createEcomApi(wixClient: WixApiClient): EcomApi {
             return items.at(0);
         },
 
-        async getCart() {
-            try {
-                const currentCart = await wixClient.currentCart.getCurrentCart();
-                return successResponse(currentCart);
-            } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetCartFailure, getErrorMessage(e));
-            }
+        getCart() {
+            return wixClient.currentCart.getCurrentCart();
         },
 
-        async getCartTotals() {
-            try {
-                const cartTotals = await wixClient.currentCart.estimateCurrentCartTotals();
-                return successResponse(cartTotals);
-            } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetCartTotalsFailure, getErrorMessage(e));
-            }
+        getCartTotals() {
+            return wixClient.currentCart.estimateCurrentCartTotals();
         },
 
         async updateCartItemQuantity(id, quantity) {
@@ -151,41 +141,25 @@ function createEcomApi(wixClient: WixApiClient): EcomApi {
             }
         },
 
-        async removeItemFromCart(id) {
-            try {
-                const result = await wixClient.currentCart.removeLineItemsFromCurrentCart([id]);
-                if (!result.cart) {
-                    throw new Error('Failed to remove cart item');
-                }
-                return successResponse(result.cart);
-            } catch (e) {
-                return failureResponse(EcomApiErrorCodes.RemoveCartItemFailure, getErrorMessage(e));
-            }
+        async removeFromCart(id) {
+            const { cart } = await wixClient.currentCart.removeLineItemsFromCurrentCart([id]);
+            return cart!;
         },
 
         async addToCart(id, quantity, options) {
-            try {
-                const result = await wixClient.currentCart.addToCurrentCart({
-                    lineItems: [
-                        {
-                            catalogReference: {
-                                catalogItemId: id,
-                                appId: WIX_STORES_APP_ID,
-                                options,
-                            },
-                            quantity,
+            const { cart } = await wixClient.currentCart.addToCurrentCart({
+                lineItems: [
+                    {
+                        catalogReference: {
+                            catalogItemId: id,
+                            appId: WIX_STORES_APP_ID,
+                            options,
                         },
-                    ],
-                });
-
-                if (!result.cart) {
-                    throw new Error('Failed to add item to cart');
-                }
-
-                return successResponse(result.cart);
-            } catch (e) {
-                return failureResponse(EcomApiErrorCodes.AddCartItemFailure, getErrorMessage(e));
-            }
+                        quantity,
+                    },
+                ],
+            });
+            return cart!;
         },
 
         async checkout() {

--- a/lib/ecom/api.ts
+++ b/lib/ecom/api.ts
@@ -115,23 +115,10 @@ const createEcomApi = (wixClient: WixApiClient): EcomApi =>
         },
 
         async updateCartItemQuantity(id, quantity) {
-            try {
-                const result = await wixClient.currentCart.updateCurrentCartLineItemQuantity([
-                    {
-                        _id: id || undefined,
-                        quantity,
-                    },
-                ]);
-                if (!result.cart) {
-                    throw new Error('Failed to update cart item quantity');
-                }
-                return successResponse(result.cart);
-            } catch (e) {
-                return failureResponse(
-                    EcomApiErrorCodes.UpdateCartItemQuantityFailure,
-                    getErrorMessage(e),
-                );
-            }
+            const { cart } = await wixClient.currentCart.updateCurrentCartLineItemQuantity([
+                { _id: id, quantity },
+            ]);
+            return cart!;
         },
 
         async removeFromCart(id) {

--- a/lib/ecom/hooks.ts
+++ b/lib/ecom/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import useSwr, { Key, SWRResponse } from 'swr';
+import useSwr, { Key, SWRResponse, mutate } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { findItemIdInCart } from '~/lib/utils';
 import { useEcomApi } from './api-context';
@@ -7,35 +7,14 @@ import { AddToCartOptions, CollectionDetails, GetProductsOptions, Product } from
 
 export const useCartData = () => {
     const ecomApi = useEcomApi();
-    return useSwr('cart', async () => {
-        const response = await ecomApi.getCart();
-        if (response.status === 'failure') {
-            throw response.error;
-        }
-
-        return response.body;
-    });
+    return useSwr('cart', () => ecomApi.getCart());
 };
 
 export const useCartTotals = () => {
     const ecomApi = useEcomApi();
-    const { data } = useCartData();
-
-    const cartTotals = useSwr('cart-totals', async () => {
-        const response = await ecomApi.getCartTotals();
-        if (response.status === 'failure') {
-            throw response.error;
-        }
-
-        return response.body;
-    });
-
-    useEffect(() => {
-        cartTotals.mutate();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data]);
-
-    return cartTotals;
+    const cart = useCartData();
+    useEffect(() => void mutate('cart-totals'), [cart.data]);
+    return useSwr('cart-totals', () => ecomApi.getCartTotals());
 };
 
 interface AddToCartArgs {
@@ -63,11 +42,7 @@ export const useAddToCart = () => {
                 return updateCartItemQuantityResponse.body;
             }
 
-            const addToCartResponse = await ecomApi.addToCart(arg.id, arg.quantity, arg.options);
-            if (addToCartResponse.status === 'failure') {
-                throw addToCartResponse.error;
-            }
-            return addToCartResponse.body;
+            return ecomApi.addToCart(arg.id, arg.quantity, arg.options);
         },
         {
             revalidate: false,
@@ -101,20 +76,10 @@ export const useUpdateCartItemQuantity = () => {
 
 export const useRemoveItemFromCart = () => {
     const ecomApi = useEcomApi();
-    return useSWRMutation(
-        'cart',
-        async (_key: Key, { arg }: { arg: string }) => {
-            const response = await ecomApi.removeItemFromCart(arg);
-            if (response.status === 'failure') {
-                throw response.error;
-            }
-            return response.body;
-        },
-        {
-            revalidate: false,
-            populateCache: true,
-        },
-    );
+    return useSWRMutation('cart', (_key, { arg }: { arg: string }) => ecomApi.removeFromCart(arg), {
+        revalidate: false,
+        populateCache: true,
+    });
 };
 
 export const useCart = () => {

--- a/lib/ecom/hooks.ts
+++ b/lib/ecom/hooks.ts
@@ -28,18 +28,14 @@ export const useAddToCart = () => {
     const { data: cart } = useCartData();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: AddToCartArgs }) => {
+        (_key: Key, { arg }: { arg: AddToCartArgs }) => {
             const itemInCart = cart ? findItemIdInCart(cart, arg.id, arg.options) : undefined;
 
             if (itemInCart) {
-                const updateCartItemQuantityResponse = await ecomApi.updateCartItemQuantity(
-                    itemInCart._id,
+                return ecomApi.updateCartItemQuantity(
+                    itemInCart._id!,
                     (itemInCart.quantity ?? 0) + arg.quantity,
                 );
-                if (updateCartItemQuantityResponse.status === 'failure') {
-                    throw updateCartItemQuantityResponse.error;
-                }
-                return updateCartItemQuantityResponse.body;
             }
 
             return ecomApi.addToCart(arg.id, arg.quantity, arg.options);
@@ -60,13 +56,8 @@ export const useUpdateCartItemQuantity = () => {
     const ecomApi = useEcomApi();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: UpdateCartItemQuantityArgs }) => {
-            const response = await ecomApi.updateCartItemQuantity(arg.id, arg.quantity);
-            if (response.status === 'failure') {
-                throw response.error;
-            }
-            return response.body;
-        },
+        (_key: Key, { arg }: { arg: UpdateCartItemQuantityArgs }) =>
+            ecomApi.updateCartItemQuantity(arg.id, arg.quantity),
         {
             revalidate: false,
             populateCache: true,

--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -16,11 +16,7 @@ export enum EcomApiErrorCodes {
     CategoryNotFound = 'CategoryNotFound',
     GetCategoryFailure = 'GetCategoryFailure',
     GetAllCategoriesFailure = 'GetAllCategoriesFailure',
-    GetCartFailure = 'GetCartFailure',
-    GetCartTotalsFailure = 'GetCartTotalsFailure',
     UpdateCartItemQuantityFailure = 'UpdateCartItemQuantityFailure',
-    RemoveCartItemFailure = 'RemoveCartItemFailure',
-    AddCartItemFailure = 'AddCartItemFailure',
     CreateCheckoutFailure = 'CreateCheckoutFailure',
     CreateCheckoutRedirectSessionFailure = 'CreateCheckoutRedirectSessionFailure',
 }
@@ -71,18 +67,14 @@ export type EcomApi = {
         options?: GetProductsOptions,
     ) => Promise<EcomApiResponse<{ items: Product[]; totalCount: number }>>;
     getProductBySlug: (slug: string) => Promise<Product | undefined>;
-    getCart: () => Promise<EcomApiResponse<Cart>>;
-    getCartTotals: () => Promise<EcomApiResponse<CartTotals>>;
+    getCart: () => Promise<Cart>;
+    getCartTotals: () => Promise<CartTotals>;
     updateCartItemQuantity: (
         id: string | undefined | null,
         quantity: number,
     ) => Promise<EcomApiResponse<Cart>>;
-    removeItemFromCart: (id: string) => Promise<EcomApiResponse<Cart>>;
-    addToCart: (
-        id: string,
-        quantity: number,
-        options?: AddToCartOptions,
-    ) => Promise<EcomApiResponse<Cart>>;
+    addToCart: (id: string, quantity: number, options?: AddToCartOptions) => Promise<Cart>;
+    removeFromCart: (id: string) => Promise<Cart>;
     checkout: () => Promise<EcomApiResponse<{ checkoutUrl: string }>>;
     getAllCategories: () => Promise<EcomApiResponse<Collection[]>>;
     getCategoryBySlug: (slug: string) => Promise<EcomApiResponse<CollectionDetails>>;

--- a/lib/ecom/types.ts
+++ b/lib/ecom/types.ts
@@ -16,7 +16,6 @@ export enum EcomApiErrorCodes {
     CategoryNotFound = 'CategoryNotFound',
     GetCategoryFailure = 'GetCategoryFailure',
     GetAllCategoriesFailure = 'GetAllCategoriesFailure',
-    UpdateCartItemQuantityFailure = 'UpdateCartItemQuantityFailure',
 }
 
 export type EcomApiError = { code: EcomApiErrorCodes; message: string };
@@ -67,10 +66,7 @@ export type EcomApi = {
     getProductBySlug: (slug: string) => Promise<Product | undefined>;
     getCart: () => Promise<Cart>;
     getCartTotals: () => Promise<CartTotals>;
-    updateCartItemQuantity: (
-        id: string | undefined | null,
-        quantity: number,
-    ) => Promise<EcomApiResponse<Cart>>;
+    updateCartItemQuantity: (id: string, quantity: number) => Promise<Cart>;
     addToCart: (id: string, quantity: number, options?: AddToCartOptions) => Promise<Cart>;
     removeFromCart: (id: string) => Promise<Cart>;
     checkout: (params: {


### PR DESCRIPTION
Migrated from error codes to exceptions:

* `EcomApi.getCart()`
* `EcomApi.getCartTotals()`
* `EcomApi.addToCart()`
* `EcomApi.removeFromCart()`
* `EcomApi.updateCartItemQuantity()`

The following two `WixClient` methods return an optional `Cart` object:
* `WixClient.currentCart.removeLineItemsFromCurrentCart()`
* `WixClient.currentCart.addToCurrentCart()`

I suspect the cart being optional is a lie, similar to `product._id` being optional. Even after removing the last item from the cart, the response still contains the cart object. I chose to ignore the type and treat the cart as always defined.