### PR TITLE
refactor: manually normalize WixClient errors

### DIFF
--- a/lib/ecom/wix-client-error.ts
+++ b/lib/ecom/wix-client-error.ts
@@ -89,3 +89,24 @@ export const normalizeWixClientError = (error: unknown): unknown => {
     }
     return error;
 };
+
+/**
+ * Wraps a function with a try-catch block that fixes broken error messages in
+ * WixClient errors and rethrows them.
+ * @see {@link getWixClientErrorMessage} for details.
+ */
+export const withNormalizedWixClientErrors = <T extends (...args: any[]) => any>(func: T): T => {
+    return function (this: unknown, ...args) {
+        try {
+            const result = func.apply(this, args);
+            if (result instanceof Promise) {
+                return result.catch((error) => {
+                    throw normalizeWixClientError(error);
+                });
+            }
+            return result;
+        } catch (error) {
+            throw normalizeWixClientError(error);
+        }
+    } as T;
+};


### PR DESCRIPTION
This is an alternative to #188 (automatically normalize WixClient errors). Just want to see if you prefer this or that.

Most changes in the diff are indentation/formatting changes caused by Prettier, I recommend turning off whitespace:

<img width="267" alt="image" src="https://github.com/user-attachments/assets/465e13b8-2d85-4b4c-9a1f-b4c3cd5156c8">
