### PR TITLE
feat: improve keyboard-focused item highlight color

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -14,5 +14,5 @@ body {
 :focus-visible {
     box-shadow:
         0 0 0 1px #ffffff,
-        0 0 0 3px #116dff;
+        0 0 0 3px var(--colorD4);
 }


### PR DESCRIPTION
update keyboard-focused item highlight color

before:
![image](https://github.com/user-attachments/assets/dcef7688-7332-4770-ad84-32c5ed3a89bd)

after:
![image](https://github.com/user-attachments/assets/d5f47b82-e2a7-42ad-b322-371e0b632637)
