### PR TITLE
Make Accordion component more customizable

### DIFF
--- a/_codux/ui-kit/components/components.board.tsx
+++ b/_codux/ui-kit/components/components.board.tsx
@@ -62,15 +62,15 @@ export default createBoard({
                             <Accordion
                                 items={[
                                     {
-                                        title: 'Product Info',
+                                        header: 'Product Info',
                                         content: 'Content',
                                     },
                                     {
-                                        title: 'Return & Refund Policy',
+                                        header: 'Return & Refund Policy',
                                         content: 'Content',
                                     },
                                     {
-                                        title: 'Shipping Info ',
+                                        header: 'Shipping Info ',
                                         content: 'Content',
                                     },
                                 ]}
@@ -120,7 +120,7 @@ export default createBoard({
         </ComponentWrapper>
     ),
     environmentProps: {
-        windowWidth: 400,
+        windowWidth: 610,
         windowHeight: 800,
     },
     isSnippet: true,

--- a/app/routes/product-details.$productSlug/route.module.scss
+++ b/app/routes/product-details.$productSlug/route.module.scss
@@ -61,6 +61,11 @@
     margin-top: 24px;
 }
 
+.additionalInfoSectionTitle {
+    font: var(--heading5);
+    font-size: 18px;
+}
+
 .socialLinks {
     margin-top: 36px;
 }

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -10,6 +10,7 @@ import { Accordion } from '~/src/components/accordion/accordion';
 import { BreadcrumbData, Breadcrumbs } from '~/src/components/breadcrumbs/breadcrumbs';
 import { RouteBreadcrumbs, useBreadcrumbs } from '~/src/components/breadcrumbs/use-breadcrumbs';
 import { ErrorPage } from '~/src/components/error-page/error-page';
+import { MinusIcon, PlusIcon } from '~/src/components/icons';
 import { ProductImages } from '~/src/components/product-images/product-images';
 import { ProductOption } from '~/src/components/product-option/product-option';
 import { ProductPrice } from '~/src/components/product-price/product-price';
@@ -161,8 +162,14 @@ export default function ProductDetailsPage() {
                         product.additionalInfoSections.length > 0 && (
                             <Accordion
                                 className={styles.additionalInfoSections}
+                                expandIcon={<PlusIcon width={22} />}
+                                collapseIcon={<MinusIcon width={22} />}
                                 items={product.additionalInfoSections.map((section) => ({
-                                    title: section.title!,
+                                    header: (
+                                        <div className={styles.additionalInfoSectionTitle}>
+                                            {section.title!}
+                                        </div>
+                                    ),
                                     content: section.description ? (
                                         <div
                                             dangerouslySetInnerHTML={{

--- a/src/components/accordion/accordion.module.scss
+++ b/src/components/accordion/accordion.module.scss
@@ -10,14 +10,19 @@
     cursor: pointer;
 }
 
-.title {
-    font: var(--heading5);
-    font-size: 18px;
+.headerContent {
+    flex-grow: 1;
 }
 
-.toggleIcon {
-    width: 22px;
-    height: 22px;
+.toggleIconContainer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-right: 4px;
+}
+
+.collapseIcon {
+    transform: rotate(180deg);
 }
 
 .content {
@@ -46,17 +51,6 @@
     padding-bottom: 25px;
 }
 
-.small {
-    .title {
-        font: var(--paragraph3);
-    }
-
-    .toggleIcon {
-        width: 20px;
-        height: 20px;
-    }
-
-    .contentInner {
-        padding-bottom: 16px;
-    }
+.small .contentInner {
+    padding-bottom: 16px;
 }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import classNames from 'classnames';
 import { getClickableElementAttributes } from '~/lib/utils';
-import { MinusIcon, PlusIcon } from '../icons';
+import { DropdownIcon } from '../icons';
 
 import styles from './accordion.module.scss';
 
 interface AccordionItem {
-    title: string;
+    header: React.ReactNode;
     content: React.ReactNode;
 }
 
@@ -14,15 +14,24 @@ interface AccordionProps {
     items: AccordionItem[];
     className?: string;
     small?: boolean;
+    expandIcon?: React.ReactNode;
+    collapseIcon?: React.ReactNode;
 }
 
-export const Accordion = ({ items, className, small = false }: AccordionProps) => {
+export const Accordion = ({
+    items,
+    className,
+    small = false,
+    expandIcon,
+    collapseIcon,
+}: AccordionProps) => {
     const [openItemIndex, setOpenItemIndex] = useState<number | null>(0);
 
     return (
         <div className={classNames({ [styles.small]: small }, className)}>
             {items.map((item, index) => {
                 const isOpen = openItemIndex === index;
+
                 return (
                     <div key={index} className={styles.item}>
                         <div
@@ -31,13 +40,18 @@ export const Accordion = ({ items, className, small = false }: AccordionProps) =
                                 setOpenItemIndex(isOpen ? null : index),
                             )}
                         >
-                            <p className={styles.title}>{item.title}</p>
+                            <div className={styles.headerContent}>{item.header}</div>
 
-                            {isOpen ? (
-                                <MinusIcon className={styles.toggleIcon} />
-                            ) : (
-                                <PlusIcon className={styles.toggleIcon} />
-                            )}
+                            <div className={styles.toggleIconContainer}>
+                                {isOpen
+                                    ? collapseIcon || (
+                                          <DropdownIcon
+                                              width={12}
+                                              className={styles.collapseIcon}
+                                          />
+                                      )
+                                    : expandIcon || <DropdownIcon width={12} />}
+                            </div>
                         </div>
 
                         <div

--- a/src/components/icons/minus-icon.tsx
+++ b/src/components/icons/minus-icon.tsx
@@ -1,11 +1,6 @@
-export const MinusIcon = ({ className }: { className?: string }) => {
+export const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => {
     return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className={className}
-        >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" {...props}>
             <path d="M4 11h11.001v-1H4v1z" clipRule="evenodd" fillRule="evenodd"></path>
         </svg>
     );

--- a/src/components/icons/plus-icon.tsx
+++ b/src/components/icons/plus-icon.tsx
@@ -1,11 +1,6 @@
-export const PlusIcon = ({ className }: { className?: string }) => {
+export const PlusIcon = (props: React.SVGProps<SVGSVGElement>) => {
     return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 16 16"
-            fill="currentColor"
-            className={className}
-        >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" {...props}>
             <path fillRule="evenodd" d="M12.5 7.5h-4v-4h-1v4h-4v1h4v4h1v-4h4v-1z"></path>
         </svg>
     );

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -8,6 +8,7 @@ import { RangeSlider } from '~/lib/components/range-slider/range-slider';
 import { formatPrice, mergeUrlSearchParams } from '~/lib/utils';
 import { useSearchParamsOptimistic } from '~/lib/hooks';
 import { Accordion } from '../accordion/accordion';
+import { MinusIcon, PlusIcon } from '../icons';
 
 interface ProductFiltersProps {
     lowestPrice: number;
@@ -35,9 +36,11 @@ export const ProductFilters = ({ lowestPrice, highestPrice, currency }: ProductF
     return (
         <Accordion
             small
+            expandIcon={<PlusIcon width={20} />}
+            collapseIcon={<MinusIcon width={20} />}
             items={[
                 {
-                    title: 'Price',
+                    header: 'Price',
                     content: (
                         <RangeSlider
                             className="rangeSlider"


### PR DESCRIPTION
To use existing `Accordion` component in "My Orders" page (see attachment below) few changes have been made:
 - added possibility to pass toggle (expand/collapse) icons
 - default toggle icons are down/up chevron icon (debatable, but in my opinion it more widespread for accordions component than plus/minus icons)
 - changed `title` to `header` for accordion items and added possibility to pass `ReactNode`

<img width="1020" alt="Screenshot 2024-11-05 at 12 02 23" src="https://github.com/user-attachments/assets/47ddbf7e-4ce8-479b-8936-8ccdecb1c6ef">
