### PR TITLE
fix: slider keyboard interaction in product filters

### DIFF
--- a/src/components/applied-product-filters/applied-product-filters.tsx
+++ b/src/components/applied-product-filters/applied-product-filters.tsx
@@ -35,8 +35,8 @@ export const AppliedProductFilters = ({
         } else {
             return (
                 <span>
-                    {formatPrice(minPrice ?? minPriceInCategory, currency)}&ndash;
-                    {formatPrice(maxPrice ?? maxPriceInCategory, currency)}
+                    {formatPrice(Math.floor(minPrice ?? minPriceInCategory), currency)}&ndash;
+                    {formatPrice(Math.ceil(maxPrice ?? maxPriceInCategory), currency)}
                 </span>
             );
         }

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -44,21 +44,17 @@ export const ProductFilters = ({ lowestPrice, highestPrice, currency }: ProductF
                     content: (
                         <RangeSlider
                             className="rangeSlider"
-                            step="any"
-                            startValue={filters.minPrice ?? lowestPrice}
-                            endValue={filters.maxPrice ?? highestPrice}
+                            step={1}
+                            startValue={Math.floor(filters.minPrice ?? lowestPrice)}
+                            endValue={Math.ceil(filters.maxPrice ?? highestPrice)}
                             onStartValueChange={(value) => {
-                                handleFiltersChange({
-                                    minPrice: Math.max(Math.floor(value), lowestPrice),
-                                });
+                                handleFiltersChange({ minPrice: value });
                             }}
                             onEndValueChange={(value) => {
-                                handleFiltersChange({
-                                    maxPrice: Math.min(Math.ceil(value), highestPrice),
-                                });
+                                handleFiltersChange({ maxPrice: value });
                             }}
-                            minValue={lowestPrice}
-                            maxValue={highestPrice}
+                            minValue={Math.floor(lowestPrice)}
+                            maxValue={Math.ceil(highestPrice)}
                             formatValue={formatPriceValue}
                         />
                     ),


### PR DESCRIPTION
Range slider in product filters has step `any` because product price could be decimal. But we round it on change simulating integer step. This works well with mouse interactions. However, it doesn't work with a keyboard. The browser determines the delta when changing the value with a keyboard (when the step is `any`). Let's say it fires a change from `3` to `3.1`. And because we round it (`Math.floor`), nothing happens, the value remains `3`.

Having step `1` instead of `any` makes it way easier to handle.
The only downside: if the minimum price in a category is decimal, let's say `3.33`, a user can set min and max price filters both to `3`. This will show no results.