### PR TITLE
fix: make avatar image cross-origin

### DIFF
--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -11,7 +11,7 @@ export interface AvatarProps {
 export const Avatar = ({ className, imageSrc }: AvatarProps) => {
     return (
         <div className={classNames(styles.root, className)}>
-            {imageSrc ? <img src={imageSrc} alt="" /> : <UserIcon />}
+            {imageSrc ? <img crossOrigin="anonymous" src={imageSrc} alt="" /> : <UserIcon />}
         </div>
     );
 };


### PR DESCRIPTION
without `crossOrigin="anonymous"` attribute, there are issues logged in dev tools saying that request is blocked according to CORB (not CORS) policy.

looks like when loading image, browser tries to send cookies (because user is logged in in gmail etc.) and this is not allowed for cross-origin requests