### PR TITLE
feat: limit max width of cards in the featured products section

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -65,6 +65,7 @@ export default function HomePage() {
                 categorySlug="new-in"
                 title="New In"
                 description="Embrace a sustainable lifestyle with our newest drop-ins."
+                productCount={4}
             />
 
             <BackgroundParallax
@@ -93,6 +94,7 @@ export default function HomePage() {
                 categorySlug="best-sellers"
                 title="Best Sellers"
                 description="When quality is eco-friendly. Explore our top picks."
+                productCount={4}
             />
         </div>
     );

--- a/src/components/featured-products-section/featured-products-section.module.scss
+++ b/src/components/featured-products-section/featured-products-section.module.scss
@@ -26,9 +26,9 @@
     text-wrap: balance;
 }
 
-.productsRow {
+.products {
     display: grid;
-    grid-auto-columns: minmax(0, 1fr);
+    grid-auto-columns: minmax(0, 640px);
     grid-auto-flow: column;
     gap: 4px;
     width: 100%;
@@ -61,7 +61,7 @@
         font-size: 14px;
     }
 
-    .productsRow {
+    .products {
         grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
         grid-auto-flow: row;
         gap: 26px 10px;

--- a/src/components/featured-products-section/featured-products-section.tsx
+++ b/src/components/featured-products-section/featured-products-section.tsx
@@ -27,7 +27,7 @@ export const FeaturedProductsSection = (props: FeaturedProductsSectionProps) => 
                     {description ?? category?.description}
                 </div>
             </FadeIn>
-            <Reveal className={styles.productsRow} direction="down" duration={1.4}>
+            <Reveal className={styles.products} direction="down" duration={1.4}>
                 {products
                     ? products.items.map((product) => (
                           <ProductLink key={product._id} productSlug={product.slug!}>

--- a/src/components/product-card/product-card.module.scss
+++ b/src/components/product-card/product-card.module.scss
@@ -1,3 +1,8 @@
+.productCard {
+    display: flex;
+    flex-direction: column;
+}
+
 .imageWrapper {
     position: relative;
     aspect-ratio: 3 / 4;

--- a/src/components/product-card/product-card.tsx
+++ b/src/components/product-card/product-card.tsx
@@ -28,7 +28,7 @@ export const ProductCard = ({
     inventoryStatus,
 }: ProductCardProps) => {
     return (
-        <div>
+        <div className={styles.productCard}>
             <div className={styles.imageWrapper}>
                 {imageUrl ? (
                     <img src={imageUrl} alt={name} className={styles.image} />


### PR DESCRIPTION
When the featured products section contains a single image, the image takes full page width, and because of 3/4 aspect ratio it's like two screens tall and huuuuge.

See here: https://github.com/wixplosives/codux/issues/23287

I've restricted the max width to 640px. Ought to be enough for anybody.

