### PR TITLE
feat: simplify error boundaries

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -70,20 +70,6 @@ export function Layout({ children }: React.PropsWithChildren) {
     );
 }
 
-interface ContentWrapperProps extends React.PropsWithChildren {
-    tokens?: Tokens;
-}
-
-function ContentWrapper({ children, tokens }: ContentWrapperProps) {
-    return (
-        <EcomApiContextProvider tokens={tokens}>
-            <CartOpenContextProvider>
-                <SiteWrapper>{children}</SiteWrapper>
-            </CartOpenContextProvider>
-        </EcomApiContextProvider>
-    );
-}
-
 export default function App() {
     const { ENV, wixEcomTokens } = useLoaderData<typeof loader>();
 
@@ -92,9 +78,13 @@ export default function App() {
     }
 
     return (
-        <ContentWrapper tokens={wixEcomTokens}>
-            <Outlet />
-        </ContentWrapper>
+        <EcomApiContextProvider tokens={wixEcomTokens}>
+            <CartOpenContextProvider>
+                <SiteWrapper>
+                    <Outlet />
+                </SiteWrapper>
+            </CartOpenContextProvider>
+        </EcomApiContextProvider>
     );
 }
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,7 +8,6 @@ import {
     ScrollRestoration,
     useLoaderData,
 } from '@remix-run/react';
-import { Tokens } from '@wix/sdk';
 import { CartOpenContextProvider } from '~/lib/cart-open-context';
 import { EcomApiContextProvider } from '~/lib/ecom';
 import { commitSession, initializeEcomSession } from '~/lib/ecom/session';

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,5 @@
 import { json, LoaderFunctionArgs } from '@remix-run/node';
 import {
-    isRouteErrorResponse,
     Links,
     Meta,
     type MetaFunction,
@@ -8,18 +7,12 @@ import {
     Scripts,
     ScrollRestoration,
     useLoaderData,
-    useNavigate,
-    useNavigation,
-    useRouteError,
 } from '@remix-run/react';
 import { Tokens } from '@wix/sdk';
-import { useEffect } from 'react';
 import { CartOpenContextProvider } from '~/lib/cart-open-context';
 import { EcomApiContextProvider } from '~/lib/ecom';
 import { commitSession, initializeEcomSession } from '~/lib/ecom/session';
-import { getErrorMessage, routeLocationToUrl } from '~/lib/utils';
 import { RouteBreadcrumbs } from '~/src/components/breadcrumbs/use-breadcrumbs';
-import { ErrorPage } from '~/src/components/error-page/error-page';
 import { SiteWrapper } from '~/src/components/site-wrapper/site-wrapper';
 
 import '~/src/styles/reset.scss';
@@ -105,31 +98,4 @@ export default function App() {
     );
 }
 
-export function ErrorBoundary() {
-    const error = useRouteError();
-    const navigation = useNavigation();
-
-    useEffect(() => {
-        if (navigation.state === 'loading') {
-            const url = routeLocationToUrl(navigation.location, window.location.origin);
-            // force full page reload after navigating from error boundary
-            // to fix remix issue with style tags disappearing
-            window.location.assign(url);
-        }
-    }, [navigation]);
-
-    const navigate = useNavigate();
-
-    const isPageNotFoundError = isRouteErrorResponse(error) && error.status === 404;
-
-    return (
-        <ContentWrapper>
-            <ErrorPage
-                title={isPageNotFoundError ? 'Page Not Found' : 'Oops, something went wrong'}
-                message={isPageNotFoundError ? undefined : getErrorMessage(error)}
-                actionButtonText="Back to shopping"
-                onActionButtonClick={() => navigate('/products/all-products')}
-            />
-        </ContentWrapper>
-    );
-}
+export { ErrorBoundary } from '~/src/components/error-page/error-page';

--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -1,15 +1,14 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 import type { GetStaticRoutes } from '@wixc3/define-remix-app';
 import classNames from 'classnames';
 import { initializeEcomApiAnonymous } from '~/lib/ecom';
 import { initializeEcomApiForRequest } from '~/lib/ecom/session';
 import { useProductDetails } from '~/lib/hooks';
-import { getErrorMessage, removeQueryStringFromUrl } from '~/lib/utils';
+import { removeQueryStringFromUrl } from '~/lib/utils';
 import { Accordion } from '~/src/components/accordion/accordion';
 import { BreadcrumbData, Breadcrumbs } from '~/src/components/breadcrumbs/breadcrumbs';
 import { RouteBreadcrumbs, useBreadcrumbs } from '~/src/components/breadcrumbs/use-breadcrumbs';
-import { ErrorPage } from '~/src/components/error-page/error-page';
 import { MinusIcon, PlusIcon } from '~/src/components/icons';
 import { ProductImages } from '~/src/components/product-images/product-images';
 import { ProductOption } from '~/src/components/product-option/product-option';
@@ -186,24 +185,4 @@ export default function ProductDetailsPage() {
     );
 }
 
-export function ErrorBoundary() {
-    const error = useRouteError();
-    const navigate = useNavigate();
-
-    let title = 'Error';
-    let message = getErrorMessage(error);
-
-    if (isRouteErrorResponse(error) && error.status === 404) {
-        title = 'Product Not Found';
-        message = "Unfortunately a product page you trying to open doesn't exist";
-    }
-
-    return (
-        <ErrorPage
-            title={title}
-            message={message}
-            actionButtonText="Back to shopping"
-            onActionButtonClick={() => navigate('/products/all-products')}
-        />
-    );
-}
+export { ErrorBoundary } from '~/src/components/error-page/error-page';

--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 import type { GetStaticRoutes } from '@wixc3/define-remix-app';
 import classNames from 'classnames';
 import {
@@ -11,12 +11,10 @@ import { initializeEcomApiForRequest } from '~/lib/ecom/session';
 import { useAppliedProductFilters } from '~/lib/hooks';
 import { useProductSorting } from '~/lib/hooks/use-product-sorting';
 import { useProductsPageResults } from '~/lib/hooks/use-products-page-results';
-import { getErrorMessage } from '~/lib/utils';
 import { AppliedProductFilters } from '~/src/components/applied-product-filters/applied-product-filters';
 import { Breadcrumbs } from '~/src/components/breadcrumbs/breadcrumbs';
 import { RouteBreadcrumbs, useBreadcrumbs } from '~/src/components/breadcrumbs/use-breadcrumbs';
 import { CategoryLink } from '~/src/components/category-link/category-link';
-import { ErrorPage } from '~/src/components/error-page/error-page';
 import { ProductFilters } from '~/src/components/product-filters/product-filters';
 import { ProductGrid } from '~/src/components/product-grid/product-grid';
 import { ProductSortingSelect } from '~/src/components/product-sorting-select/product-sorting-select';
@@ -182,24 +180,4 @@ export default function ProductsPage() {
     );
 }
 
-export function ErrorBoundary() {
-    const error = useRouteError();
-    const navigate = useNavigate();
-
-    let title = 'Error';
-    let message = getErrorMessage(error);
-
-    if (isRouteErrorResponse(error) && error.status === 404) {
-        title = 'Category Not Found';
-        message = "Unfortunately, the category page you're trying to open does not exist";
-    }
-
-    return (
-        <ErrorPage
-            title={title}
-            message={message}
-            actionButtonText="Back to shopping"
-            onActionButtonClick={() => navigate('/products/all-products')}
-        />
-    );
-}
+export { ErrorBoundary } from '~/src/components/error-page/error-page';

--- a/app/routes/thank-you/route.tsx
+++ b/app/routes/thank-you/route.tsx
@@ -1,9 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData, useRouteError } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 import { initializeEcomApiForRequest } from '~/lib/ecom/session';
-import { getErrorMessage } from '~/lib/utils';
 import { CategoryLink } from '~/src/components/category-link/category-link';
-import { ErrorPage } from '~/src/components/error-page/error-page';
 import { OrderSummary } from '~/src/components/order-summary/order-summary';
 
 import styles from './route.module.scss';
@@ -39,7 +37,4 @@ export default function ThankYouPage() {
     );
 }
 
-export function ErrorBoundary() {
-    const error = useRouteError();
-    return <ErrorPage title="Error" message={getErrorMessage(error)} />;
-}
+export { ErrorBoundary } from '~/src/components/error-page/error-page';

--- a/lib/utils/common.ts
+++ b/lib/utils/common.ts
@@ -1,4 +1,4 @@
-import { isRouteErrorResponse, Location } from '@remix-run/react';
+import { isRouteErrorResponse } from '@remix-run/react';
 
 /**
  * It's important to add an appropriate role and a keyboard support
@@ -60,16 +60,6 @@ export function getErrorMessage(error: unknown): string {
     }
 
     return String(error);
-}
-
-/**
- * Converts Remix Location object into a standard URL object.
- */
-export function routeLocationToUrl(location: Location, origin: string): URL {
-    const url = new URL(location.pathname, origin);
-    url.search = location.search;
-    url.hash = location.hash;
-    return url;
 }
 
 /**

--- a/src/components/error-page/error-page.module.scss
+++ b/src/components/error-page/error-page.module.scss
@@ -1,6 +1,6 @@
 .root {
     padding: 48px 0;
-    min-height: 50vh;
+    min-height: 70vh;
     max-width: 40em;
     margin: 0 auto;
     display: flex;

--- a/src/components/error-page/error-page.tsx
+++ b/src/components/error-page/error-page.tsx
@@ -43,9 +43,10 @@ export const ErrorBoundary = () => {
         message = '';
     }
 
-    // In Remix dev mode, if an error bubbles up to a parent route's error
-    // boundary and then the user navigates away, some style tags disappear.
-    // This can be prevented by forcing a full page load.
+    // In Remix dev mode, if an error bubbles up from a child route to a parent
+    // route's error boundary, and the user then follows a link, some style tags
+    // disappear. To prevent this, we force a full page load upon navigation
+    // from the error boundary.
     useEffect(() => {
         if (navigation.state === 'loading') {
             const { pathname, search, hash } = navigation.location;

--- a/src/components/error-page/error-page.tsx
+++ b/src/components/error-page/error-page.tsx
@@ -1,4 +1,6 @@
-import { FC } from 'react';
+import { isRouteErrorResponse, useNavigate, useNavigation, useRouteError } from '@remix-run/react';
+import { FC, useEffect } from 'react';
+import { getErrorMessage } from '~/lib/utils';
 
 import styles from './error-page.module.scss';
 
@@ -25,5 +27,38 @@ export const ErrorPage: FC<ErrorPageProps> = ({
                 </button>
             ) : null}
         </div>
+    );
+};
+
+export const ErrorBoundary = () => {
+    const error = useRouteError();
+    const navigation = useNavigation();
+    const navigate = useNavigate();
+
+    let title = 'Something Went Wrong';
+    let message = getErrorMessage(error);
+
+    if (isRouteErrorResponse(error) && error.status === 404) {
+        title = 'Page Not Found';
+        message = '';
+    }
+
+    // In Remix dev mode, if an error bubbles up to a parent route's error
+    // boundary and then the user navigates away, some style tags disappear.
+    // This can be prevented by forcing a full page load.
+    useEffect(() => {
+        if (navigation.state === 'loading') {
+            const { pathname, search, hash } = navigation.location;
+            window.location.assign(pathname + search + hash);
+        }
+    }, [navigation]);
+
+    return (
+        <ErrorPage
+            title={title}
+            message={message}
+            actionButtonText="Back to shopping"
+            onActionButtonClick={() => navigate('/products/all-products')}
+        />
     );
 };


### PR DESCRIPTION
I want to reuse the same error boundary component across all routes for simplicity and consistency.

A route like `app/routes/products.$categorySlug/route.tsx` can simply include:
```ts
export { ErrorBoundary } from '~/src/components/error-page/error-page';
```

Apart from refactoring, there are a couple of functional changes in this PR:

For the 404 error, we had two custom messages: "Category Not Found" and "Product Not Found." I didn't feel the need to preserve these (though it would be easy to do), so now both display as "Page Not Found."

The root error boundary had a subtle issue: to display the site header, it rendered `<ContentWrapper>`, which rendered `<SiteWrapper>`, which rendered components like `<Cart>`, which can throw errors. So the error boundary component rendered something that can throw, which is not ideal. To avoid this, I've sacrificed showing the site header when we hit the root error boundary:

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/103215a8-f006-4e01-a869-dc2a079f4d71">

---

But for cases like a non-existent category, the header is still included, because the category page is a nested route with its own error boundary. We could include a simple static header with the site name in the top-level error boundary, but I think even without it it's good enough.

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/39e9c1e3-2055-432f-a941-daf39c8f86fd">
