### PR TITLE
fix: improve detection of 'category not found' error

### DIFF
--- a/lib/ecom/wix-client-error.ts
+++ b/lib/ecom/wix-client-error.ts
@@ -75,7 +75,7 @@ const getWixClientErrorCode = (error: WixClientError): number | string | undefin
 
 export const isNotFoundWixClientError = (error: unknown): boolean => {
     const code = isWixClientError(error) ? getWixClientErrorCode(error) : undefined;
-    return code === 404 || code === 'NOT_FOUND';
+    return code === 404 || (isString(code) && code.includes('NOT_FOUND'));
 };
 
 /**

--- a/src/components/error-page/error-page.tsx
+++ b/src/components/error-page/error-page.tsx
@@ -48,7 +48,7 @@ export const ErrorBoundary = () => {
     // disappear. To prevent this, we force a full page load upon navigation
     // from the error boundary.
     useEffect(() => {
-        if (navigation.state === 'loading') {
+        if (import.meta.env.MODE === 'development' && navigation.state === 'loading') {
             const { pathname, search, hash } = navigation.location;
             window.location.assign(pathname + search + hash);
         }


### PR DESCRIPTION
When a category is not found, the Wix Ecom API chooses seemingly at random between two responses with different error codes `404` and `"CATEGORY_NOT_FOUND"`:
```
{
    "message": "Collection with slug baths was not found",
    "details": {
        "applicationError": {
            "description": "Collection with slug baths was not found",
            "code": 404
        }
    }
}
```

```
{
    "message": "Collection with slug baths was not found for store 48734ffb-74ca-4fd1-b041-935e8ecaaad3: UNKNOWN",
    "details": {
        "applicationError": {
            "description": "UNKNOWN",
            "code": "CATEGORY_NOT_FOUND",
        }
    }
}
```

There's also a third code, `"NOT_FOUND"`, used by some other endpoints.

Also included in this PR a tweak to the workaround for Remix losing styles upon navigation from an error boundary. I've verified that the workaround is only needed in dev mode, but not in production mode, so I've disabled it in production.