### PR TITLE
fix: ensure dev cold start doesn't reload

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,5 +17,8 @@ export default defineConfig({
             '@styles': path.resolve(__dirname, './src/styles/'),
         },
     },
+    optimizeDeps: {
+        include: ['@radix-ui/react-select'],
+    },
     css: { preprocessorOptions: { scss: { api: 'modern' } } },
 });


### PR DESCRIPTION
Fixes a dev-time issue observed consistently.

After a fresh (!) `node_modules` installation, and executing `npm run dev`, going to http://localhost:5173 and clicking on one of the categories causes a full reload with the message vite is optimizing `@radix-ui/react-select` and full reloads the page.

Vite tries to auto detect deps that require its optimization ahead of time, and for some reason it doesn't finds these from another route. Probably remix not configuring entrypoints correctly, or choosing to be lazy.

Using https://vite.dev/config/dep-optimization-options.html#optimizedeps-include we can avoid the first time reload.