### PR TITLE
feat: Tweaks to the Accordion and OrderSummary component

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -172,6 +172,7 @@ export default function ProductDetailsPage() {
                                         />
                                     ) : null,
                                 }))}
+                                initialOpenItemIndex={0}
                             />
                         )}
 

--- a/app/routes/thank-you/route.module.scss
+++ b/app/routes/thank-you/route.module.scss
@@ -12,8 +12,12 @@
 }
 
 .orderNumber {
-    margin-bottom: 32px;
+    margin-bottom: 52px;
     font: var(--paragraph3);
+}
+
+.orderSummary {
+    max-width: 800px;
 }
 
 .link {

--- a/app/routes/thank-you/route.tsx
+++ b/app/routes/thank-you/route.tsx
@@ -26,7 +26,7 @@ export default function ThankYouPage() {
             {order && (
                 <>
                     <div className={styles.orderNumber}>Order number: {order.number}</div>
-                    <OrderSummary order={order} />
+                    <OrderSummary order={order} className={styles.orderSummary} />
                 </>
             )}
 

--- a/src/components/accordion/accordion.module.scss
+++ b/src/components/accordion/accordion.module.scss
@@ -3,7 +3,7 @@
 }
 
 .header {
-    height: 48px;
+    min-height: 48px;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -12,6 +12,7 @@ interface AccordionItem {
 
 interface AccordionProps {
     items: AccordionItem[];
+    initialOpenItemIndex?: number;
     className?: string;
     small?: boolean;
     expandIcon?: React.ReactNode;
@@ -20,12 +21,13 @@ interface AccordionProps {
 
 export const Accordion = ({
     items,
+    initialOpenItemIndex,
     className,
     small = false,
     expandIcon,
     collapseIcon,
 }: AccordionProps) => {
-    const [openItemIndex, setOpenItemIndex] = useState<number | null>(0);
+    const [openItemIndex, setOpenItemIndex] = useState<number | null>(initialOpenItemIndex ?? null);
 
     return (
         <div className={classNames({ [styles.small]: small }, className)}>

--- a/src/components/order-summary/order-item/order-item.tsx
+++ b/src/components/order-summary/order-item/order-item.tsx
@@ -30,7 +30,7 @@ export const OrderItem = ({ item }: OrderItemProps) => {
                 <div>
                     <div>{productName}</div>
                     <div className={styles.productDetails}>
-                        <div>{item.price?.formattedAmount}</div>
+                        <div>Price: {item.price?.formattedAmount}</div>
                         {item.descriptionLines?.map(({ name, colorInfo, plainText }, index) => {
                             const displayName = name?.translated ?? name?.original;
                             const colorName = colorInfo?.translated ?? colorInfo?.original;

--- a/src/components/order-summary/order-summary.module.scss
+++ b/src/components/order-summary/order-summary.module.scss
@@ -66,8 +66,6 @@
 }
 
 @media (max-width: $mobile-width) {
-    
-
     .summary {
         grid-template-columns: 1fr;
     }

--- a/src/components/order-summary/order-summary.module.scss
+++ b/src/components/order-summary/order-summary.module.scss
@@ -2,19 +2,15 @@
 
 .root {
     width: 100%;
-    max-width: 800px;
-}
-
-.section {
-    padding: 40px;
-    border: 1px solid var(--primary2);
 }
 
 .divider {
-    height: 1px;
-    background: var(--primary2);
-    border: none;
+    border-bottom: 1px solid var(--secondary1);
     margin: 20px 0;
+}
+
+.divider.dashed {
+    border-bottom-style: dashed;
 }
 
 .orderItems {
@@ -70,9 +66,7 @@
 }
 
 @media (max-width: $mobile-width) {
-    .section {
-        padding: 20px;
-    }
+    
 
     .summary {
         grid-template-columns: 1fr;

--- a/src/components/order-summary/order-summary.tsx
+++ b/src/components/order-summary/order-summary.tsx
@@ -1,14 +1,15 @@
+import classNames from 'classnames';
 import { orders } from '@wix/ecom';
+import type { SerializeFrom } from '@remix-run/node';
 import { OrderItem } from './order-item/order-item';
 import styles from './order-summary.module.scss';
-import type { SerializeFrom } from '@remix-run/node';
-import classNames from 'classnames';
 
 export interface OrderSummaryProps {
+    className?: string;
     order: SerializeFrom<orders.Order & orders.OrderNonNullableFields>;
 }
 
-export const OrderSummary = ({ order }: OrderSummaryProps) => {
+export const OrderSummary = ({ order, className }: OrderSummaryProps) => {
     const { lineItems, priceSummary, shippingInfo, billingInfo, buyerNote } = order;
 
     const deliveryContact = shippingInfo?.logistics?.shippingDestination?.contactDetails;
@@ -19,7 +20,7 @@ export const OrderSummary = ({ order }: OrderSummaryProps) => {
     const billingAddress = billingInfo?.address;
 
     return (
-        <div className={styles.root}>
+        <div className={classNames(styles.root, className)}>
             <div className={styles.section}>
                 <div className={styles.orderItems}>
                     {lineItems.map((item) => (
@@ -68,6 +69,8 @@ export const OrderSummary = ({ order }: OrderSummaryProps) => {
                     </div>
                 </div>
             </div>
+
+            <hr className={classNames(styles.divider, styles.dashed)} />
 
             <div className={classNames(styles.section, styles.addressSection)}>
                 <div>

--- a/src/components/product-filters/product-filters.tsx
+++ b/src/components/product-filters/product-filters.tsx
@@ -60,6 +60,7 @@ export const ProductFilters = ({ lowestPrice, highestPrice, currency }: ProductF
                     ),
                 },
             ]}
+            initialOpenItemIndex={0}
         />
     );
 };


### PR DESCRIPTION
These changes needed for the `MyOrders` page that will come in the next PR

Accordion:
 - added `initialOpenItemIndex` prop (currently first item is opened by default)

OrderSummary:
 - UI tweaks (to be able to use the same component in the "Thank You" and "My Orders" pages)
 - added "Price" label in the order item details

Updated `OrderSummary` on the Thank You page looks like this:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/d5e1a218-4c74-4ce4-a2c2-aba7641bec73">
