### PR TITLE
fix: force consistent order of CSS between dev and prod

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,15 @@ export default defineConfig({
         include: ['@radix-ui/react-select'],
     },
     css: { preprocessorOptions: { scss: { api: 'modern' } } },
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks(id) {
+                    if (id.endsWith('.css') || id.endsWith('.scss')) {
+                        return 'styles';
+                    }
+                },
+            },
+        },
+    },
 });


### PR DESCRIPTION
Imagine you have a `<Select>` component with sensible default styling:
```scss
/* select.module.css */
.select { color: inherit; }
```

You add it to the home page, and apply a small styling tweak:
```css
/* home-page.module.css */
.pinkSelect { color: hotpink; }
```

```tsx
/* home-page.tsx */
import { Select } from '../components/select';
import styles from './home-page.module.css';

export const HomePage = () => <Select className={styles.pinkSelect} />;
```

Things look great both in development and production.

Then you add the select component to another page. Everything still looks great in development, but in production you notice that the Select component's styling is broken on the home page. Even though you didn't touch the home page or the select component.

Here's what happened:

When the select component was only used on the home page, Vite included it in the home page's CSS bundle. But after adding it to another page, Vite extracted the select component's CSS into a separate bundle to avoid duplication. Then it decided to load this bundle after the page's main CSS, breaking the original order of CSS imports. And this isn't even client-side routing, it's SSR with a full page load.

Remix documentation says: well, [write your CSS in a way that makes it resilient against changes to the file ordering](https://remix.run/docs/en/main/guides/css-files#css-order-can-differ-between-development-and-production). But we can't expect that from Codux users. I wouldn't trust that I could do it myself (maybe with `@layer`, but Codux doesn't support it).

So, what are our options?

1. **A single CSS bundle per route.** This is reliable and can handle cases like routes importing styles in different orders (e.g., one route importing `a.css`, `b.css` and another importing `b.css`, `a.css`). It should work well with client-side routing, since Remix removes the route's CSS from the `<head>` when navigating to a different route. The downside is duplicating 20–30KB of CSS for each route. But I like this option.
2. **A single CSS bundle for the entire site**. This should work fine as long as routes import CSS files in a consistent order.
3. **A magic Vite plugin/configuration** that makes the production build behave like development.

In this PR I went with option 2 - a single CSS bundle for the entire site. I tried `build.cssCodeSplit: false` but couldn't figure out how to include the resulting CSS bundle in the HTML, since the filename is dynamic. So I'm probably doing things wrong, but I can't make sense of Vite's documentation.