### PR TITLE
feat: add board template with component wrapper

### DIFF
--- a/_codux/board-templates/Default.board.tsx
+++ b/_codux/board-templates/Default.board.tsx
@@ -3,6 +3,9 @@ import ComponentWrapper from '_codux/board-wrappers/component-wrapper';
 
 export default createBoard({
     name: 'New Board',
-    Board: () => <ComponentWrapper />,
-    isSnippet: false,
+    Board: () => (
+        <ComponentWrapper>
+            <div></div>
+        </ComponentWrapper>
+    ),
 });

--- a/_codux/board-templates/DefaultBoard.board.tsx
+++ b/_codux/board-templates/DefaultBoard.board.tsx
@@ -1,0 +1,8 @@
+import { createBoard } from '@wixc3/react-board';
+import ComponentWrapper from '_codux/board-wrappers/component-wrapper';
+
+export default createBoard({
+    name: 'New Board',
+    Board: () => <ComponentWrapper />,
+    isSnippet: false,
+});

--- a/codux.config.json
+++ b/codux.config.json
@@ -10,6 +10,9 @@
     "componentsPath": "src/components",
     "templatesPath": "_codux/component-templates"
   },
+  "newBoard": {
+    "templatesPath": "_codux/board-templates"
+  },
   "safeRender": {
     "maxInstancesPerComponent": 1000
   },
@@ -29,7 +32,10 @@
   },
   "resolve": {
     "alias": {
-      "~/*": "./*",
+      "@styles": "./src/styles",
+      "@styles/*": "./src/styles/*",
+      "/*": "./*",
+      "~/*": "./src/*",
       "node:fs": false,
       "node:fs/promises": false,
       "node:path": false,

--- a/codux.config.json
+++ b/codux.config.json
@@ -32,10 +32,7 @@
   },
   "resolve": {
     "alias": {
-      "@styles": "./src/styles",
-      "@styles/*": "./src/styles/*",
-      "/*": "./*",
-      "~/*": "./src/*",
+      "~/*": "./*",
       "node:fs": false,
       "node:fs/promises": false,
       "node:path": false,


### PR DESCRIPTION
https://github.com/user-attachments/assets/3c7faa40-cca7-4ff7-8bae-d4cf2bf9f8ec

### Note

If you use NewComponent dialog and want to see DefaultBoard template there you need to use `<ContentSlot/>`. [Read more](https://help.codux.com/kb/en/article/creating-board-templates#using-a-board-template-for-new-components)