### PR TITLE
feat: page loading indicator for client-side navigation

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,14 +14,15 @@ import {
     ScrollRestoration,
     useLoaderData,
 } from '@remix-run/react';
-import { CartOpenContextProvider } from '~/src/wix/cart';
-import { EcomApiContextProvider, getWixClientId, setWixClientId } from '~/src/wix/ecom';
-import { commitSession, initializeEcomSession } from '~/src/wix/ecom/session';
 import { RouteBreadcrumbs } from '~/src/components/breadcrumbs/use-breadcrumbs';
 import { Cart } from '~/src/components/cart/cart';
 import { Footer } from '~/src/components/footer/footer';
 import { Header } from '~/src/components/header/header';
+import { NavigationProgress } from '~/src/components/navigation-progress/navigation-progress';
 import { Toaster } from '~/src/components/toaster/toaster';
+import { CartOpenContextProvider } from '~/src/wix/cart';
+import { EcomApiContextProvider, getWixClientId, setWixClientId } from '~/src/wix/ecom';
+import { commitSession, initializeEcomSession } from '~/src/wix/ecom/session';
 
 import styles from './root.module.scss';
 
@@ -81,6 +82,7 @@ export default function App() {
                     <Footer />
                 </div>
                 <Cart />
+                <NavigationProgress />
                 <Toaster />
             </CartOpenContextProvider>
         </EcomApiContextProvider>

--- a/src/components/navigation-progress/navigation-progress.module.scss
+++ b/src/components/navigation-progress/navigation-progress.module.scss
@@ -1,0 +1,55 @@
+.progressBar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 3px;
+    pointer-events: none;
+    background-color: var(--navigation-progress-color, #007bff);
+}
+
+.progressBar.loading {
+    animation: loadingAnimation 100s forwards;
+}
+
+.progressBar.finished {
+    /** Combining the 'loading' and 'finished' animations allows for a smooth
+     * transition when removing the .loading class and adding .finished, as the
+     * browser retains the 'loading' animation's state, and the 'finished'
+     * animation uses that as the initial state.
+     */
+    animation:
+        loadingAnimation 100s forwards,
+        finishedAnimation 0.3s forwards;
+}
+
+@keyframes loadingAnimation {
+    /** Start quickly to make the progress bar clearly visible */
+    0% {
+        width: 0;
+        animation-timing-function: cubic-bezier(0.55, 0.1, 0.15, 0.9);
+    }
+    0.5% {
+        width: 15%;
+        animation-timing-function: cubic-bezier(0.33, 1, 0.68, 1);
+    }
+    /** Continue gradually, decelerating toward the end and never reaching it */
+    100% {
+        width: 95%;
+    }
+}
+
+@keyframes finishedAnimation {
+    0% {
+        animation-timing-function: ease-out;
+    }
+    50% {
+        opacity: 1;
+    }
+    90% {
+        width: 100%;
+    }
+    100% {
+        opacity: 0;
+    }
+}

--- a/src/components/navigation-progress/navigation-progress.tsx
+++ b/src/components/navigation-progress/navigation-progress.tsx
@@ -1,0 +1,34 @@
+import { useNavigation } from '@remix-run/react';
+import { FC, useEffect, useRef } from 'react';
+import classNames from 'classnames';
+
+import styles from './navigation-progress.module.scss';
+
+export interface NavigationProgressProps {
+    className?: string;
+}
+
+/**
+ * A slim progress bar displayed at the top of the page during client-side
+ * navigation. It provides visual feedback since browsers don't show a loading
+ * indicator when pages load via client-side routing.
+ */
+export const NavigationProgress: FC<NavigationProgressProps> = ({ className }) => {
+    const progressBarRef = useRef<HTMLDivElement>(null);
+    const navigation = useNavigation();
+    const isLoading = navigation.state !== 'idle';
+
+    useEffect(() => {
+        const div = progressBarRef.current!;
+        if (isLoading) {
+            div.classList.remove(styles.finished);
+            div.getAnimations().forEach((animation) => animation.cancel());
+            div.classList.add(styles.loading);
+        } else if (div.classList.contains(styles.loading)) {
+            div.classList.remove(styles.loading);
+            div.classList.add(styles.finished);
+        }
+    }, [isLoading]);
+
+    return <div ref={progressBarRef} className={classNames(styles.progressBar, className)} />;
+};

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -17,5 +17,5 @@
     --focus-ring-color: #5b4b34;
 
     /** Thin progress bar displayed at the top of the page when it's loading. */
-    --navigation-progress-color: var(--secondary4);
+    --navigation-progress-color: #7D6283;
 }

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -17,5 +17,5 @@
     --focus-ring-color: #5b4b34;
 
     /** Thin progress bar displayed at the top of the page when it's loading. */
-    --navigation-progress-color: #7D6283;
+    --navigation-progress-color: #7d6283;
 }

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,7 +1,4 @@
 :root {
-    --error: #df3131;
-    --focus-ring-color: #5b4b34;
-
     --primary1: #fef9ec;
     --primary2: #ffefc7;
     --primary3: #dad3c1;
@@ -13,4 +10,12 @@
     --secondary3: #707365;
     --secondary4: #414434;
     --secondary5: #22241b;
+
+    --error: #df3131;
+
+    /** Focus ring that appears when an element is focused via keyboard. */
+    --focus-ring-color: #5b4b34;
+
+    /** Thin progress bar displayed at the top of the page when it's loading. */
+    --navigation-progress-color: var(--secondary4);
 }


### PR DESCRIPTION
A little progress bar at the top of the page that is displayed during client-side navigation:

https://github.com/user-attachments/assets/770b3350-7fee-4eb4-a1b8-e0b113e6436f
