### PR TITLE
feat: use a toast instead of an alert on the browse products page

### DIFF
--- a/app/routes/products.$categorySlug/route.tsx
+++ b/app/routes/products.$categorySlug/route.tsx
@@ -2,6 +2,7 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
 import { type MetaFunction, useLoaderData } from '@remix-run/react';
 import type { GetStaticRoutes } from '@wixc3/define-remix-app';
 import classNames from 'classnames';
+import { useEffect } from 'react';
 import { AppliedProductFilters } from '~/src/components/applied-product-filters/applied-product-filters';
 import { Breadcrumbs } from '~/src/components/breadcrumbs/breadcrumbs';
 import { RouteBreadcrumbs, useBreadcrumbs } from '~/src/components/breadcrumbs/use-breadcrumbs';
@@ -9,6 +10,7 @@ import { CategoryLink } from '~/src/components/category-link/category-link';
 import { ProductFilters } from '~/src/components/product-filters/product-filters';
 import { ProductGrid } from '~/src/components/product-grid/product-grid';
 import { ProductSortingSelect } from '~/src/components/product-sorting-select/product-sorting-select';
+import { toast } from '~/src/components/toast/toast';
 import { initializeEcomApiAnonymous } from '~/src/wix/ecom';
 import { initializeEcomApiForRequest } from '~/src/wix/ecom/session';
 import {
@@ -18,6 +20,7 @@ import {
     useProductSorting,
     useProductsPageResults,
 } from '~/src/wix/products';
+import { getErrorMessage } from '~/src/wix/utils';
 
 import styles from './route.module.scss';
 
@@ -74,8 +77,10 @@ export default function ProductsPage() {
 
     const { appliedFilters, someFiltersApplied, clearFilters, clearAllFilters } =
         useAppliedProductFilters();
+
     const { sorting } = useProductSorting();
-    const { products, totalProducts, loadMoreProducts, isLoadingMoreProducts } =
+
+    const { products, totalProducts, loadMoreProducts, isLoadingMoreProducts, error } =
         useProductsPageResults({
             categoryId: category._id!,
             filters: appliedFilters,
@@ -86,6 +91,10 @@ export default function ProductsPage() {
     const currency = products[0]?.priceData?.currency ?? 'USD';
 
     const breadcrumbs = useBreadcrumbs();
+
+    useEffect(() => {
+        if (error) toast.error(getErrorMessage(error));
+    }, [error]);
 
     return (
         <div className={styles.page}>

--- a/src/wix/products/use-products-page-results.ts
+++ b/src/wix/products/use-products-page-results.ts
@@ -1,7 +1,6 @@
 import { SerializeFrom } from '@remix-run/node';
 import { useEffect, useRef, useState } from 'react';
 import { IProductFilters, Product, ProductSortBy, useEcomApi } from '../ecom';
-import { getErrorMessage } from '../utils';
 
 export interface ProductsPageResults {
     items: (Product | SerializeFrom<Product>)[];
@@ -34,10 +33,12 @@ export function useProductsPageResults({
     // When the category or filters change, the loader fetches the first batch of new
     // results without a full-page reload, and we need to reset the list of results.
     useEffect(() => {
+        setError(undefined);
         setResults(resultsFromLoader);
     }, [resultsFromLoader]);
 
     const [isLoadingMoreProducts, setIsLoadingMoreProducts] = useState(false);
+    const [error, setError] = useState<unknown>();
 
     const ecomApi = useEcomApi();
 
@@ -54,13 +55,14 @@ export function useProductsPageResults({
             });
 
             if (resultsRef.current === resultsBeforeFetch) {
+                setError(undefined);
                 setResults((prev) => ({
                     totalCount: response.totalCount,
                     items: [...prev.items, ...response.items],
                 }));
             }
-        } catch (e) {
-            alert(getErrorMessage(e));
+        } catch (error) {
+            setError(error);
         } finally {
             setIsLoadingMoreProducts(false);
         }
@@ -71,5 +73,6 @@ export function useProductsPageResults({
         totalProducts: results.totalCount,
         isLoadingMoreProducts,
         loadMoreProducts,
+        error,
     };
 }


### PR DESCRIPTION
When clicking 'Load more' on the products page, show a toast instead of an alert in case of an error response.