### PR TITLE
feat: enable future flags for forward compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,13 @@ import { netlifyPlugin } from '@netlify/remix-adapter/plugin';
 export default defineConfig({
     plugins: [
         remix({
+            future: {
+                v3_fetcherPersist: true,
+                v3_lazyRouteDiscovery: true,
+                v3_relativeSplatPath: true,
+                v3_singleFetch: true,
+                v3_throwAbortReason: true,
+            },
             ignoredRouteFiles: ['**/*.module.scss'],
         }),
         netlifyPlugin(),


### PR DESCRIPTION
remix warns about these today, as they are going to change the behavior in remix@3 / react-router@7.
by enabling the flags, we turn on the new behavior today.
everything seems to work pretty snappy from my own testing.

this also fixes all the warnings during `npm run dev` since the latest version of remix.