### PR TITLE
fix: correctly read WIX_CLIENT_ID from the .env file when running in Codux

### DIFF
--- a/src/wix/ecom/api.ts
+++ b/src/wix/ecom/api.ts
@@ -30,14 +30,17 @@ const DEMO_WIX_CLIENT_ID = '35a15d20-4732-4bb8-a8ef-194fd1166827';
  * - https://dev.wix.com/docs/go-headless/coding/java-script-sdk/visitors-and-members/create-a-client-with-oauth
  * - https://dev.wix.com/docs/go-headless/getting-started/setup/authentication/create-an-oauth-app-for-visitors-and-members
  */
-let WIX_CLIENT_ID = globalThis.process?.env?.WIX_CLIENT_ID ?? DEMO_WIX_CLIENT_ID;
+let WIX_CLIENT_ID: string | undefined;
 
-export function getWixClientId() {
-    return WIX_CLIENT_ID;
+export function getWixClientId(): string {
+    if (typeof process !== 'undefined' && process.env.WIX_CLIENT_ID) {
+        return process.env.WIX_CLIENT_ID;
+    }
+    return WIX_CLIENT_ID ?? DEMO_WIX_CLIENT_ID;
 }
 
-export function setWixClientId(clientId: string) {
-    WIX_CLIENT_ID = clientId;
+export function setWixClientId(id: string): void {
+    WIX_CLIENT_ID = id;
 }
 
 export function createWixClient(tokens?: Tokens): WixApiClient {


### PR DESCRIPTION
In #226, I changed `process.env.WIX_CLIENT_ID` to `globalThis.process.env.WIX_CLIENT_ID` to avoid the clunky `typeof process !== 'undefined'`.

In Node, they're interchangable because of course they are. But when Codux copies `process` into the preview environment, it somehow breaks access through `globalThis`.

Anyway, I've changed it back.