### PR TITLE
feat: auto-adjust slider step size to price range in price filter

### DIFF
--- a/src/components/applied-product-filters/applied-product-filters.tsx
+++ b/src/components/applied-product-filters/applied-product-filters.tsx
@@ -35,8 +35,8 @@ export const AppliedProductFilters = ({
         } else {
             return (
                 <span>
-                    {formatPrice(Math.floor(minPrice ?? minPriceInCategory), currency)}&ndash;
-                    {formatPrice(Math.ceil(maxPrice ?? maxPriceInCategory), currency)}
+                    {formatPrice(minPrice ?? minPriceInCategory, currency)}&ndash;
+                    {formatPrice(maxPrice ?? maxPriceInCategory, currency)}
                 </span>
             );
         }

--- a/src/components/product-filters/price-filter.tsx
+++ b/src/components/product-filters/price-filter.tsx
@@ -3,6 +3,7 @@ import { Slider } from '../slider/slider';
 import { formatPrice } from '~/src/wix/products';
 import { useDebouncedCallback } from '~/src/wix/utils';
 import styles from './price-filter.module.scss';
+import { alignRangeToNiceStep } from '~/src/wix/utils/align-range';
 
 export interface PriceFilterProps {
     minAvailablePrice: number;
@@ -21,13 +22,14 @@ export const PriceFilter: FC<PriceFilterProps> = ({
     currency,
     onChange,
 }) => {
-    // Round available prices to the nearest whole number to ensure the slider
-    // thumbs can reach the track's start and end, as they move only in integer
-    // steps.
-    minAvailablePrice = Math.floor(minAvailablePrice);
-    maxAvailablePrice = Math.ceil(maxAvailablePrice);
-    minSelectedPrice ??= minAvailablePrice;
-    maxSelectedPrice ??= maxAvailablePrice;
+    const sliderRange = alignRangeToNiceStep({
+        min: minAvailablePrice,
+        max: maxAvailablePrice,
+        step: Math.max(0.1, (maxAvailablePrice - minAvailablePrice) / 100),
+    });
+
+    minSelectedPrice ??= sliderRange.min;
+    maxSelectedPrice ??= sliderRange.max;
 
     const [value, setValue] = useState([minSelectedPrice, maxSelectedPrice]);
     useEffect(() => {
@@ -51,9 +53,9 @@ export const PriceFilter: FC<PriceFilterProps> = ({
         <div className={styles.root}>
             <Slider
                 className="slider"
-                min={minAvailablePrice}
-                max={maxAvailablePrice}
-                step={1}
+                min={sliderRange.min}
+                max={sliderRange.max}
+                step={sliderRange.step}
                 value={value}
                 onValueChange={setValue}
                 onValueCommit={handleValueCommit}

--- a/src/components/product-filters/price-filter.tsx
+++ b/src/components/product-filters/price-filter.tsx
@@ -1,9 +1,9 @@
 import { FC, useEffect, useRef, useState } from 'react';
-import { Slider } from '../slider/slider';
 import { formatPrice } from '~/src/wix/products';
 import { useDebouncedCallback } from '~/src/wix/utils';
-import styles from './price-filter.module.scss';
 import { alignRangeToNiceStep } from '~/src/wix/utils/align-range';
+import { Slider } from '../slider/slider';
+import styles from './price-filter.module.scss';
 
 export interface PriceFilterProps {
     minAvailablePrice: number;
@@ -22,10 +22,11 @@ export const PriceFilter: FC<PriceFilterProps> = ({
     currency,
     onChange,
 }) => {
+    const priceRange = maxAvailablePrice - minAvailablePrice;
     const sliderRange = alignRangeToNiceStep({
         min: minAvailablePrice,
         max: maxAvailablePrice,
-        step: Math.max(0.1, (maxAvailablePrice - minAvailablePrice) / 100),
+        step: Math.max(priceRange / 100, 0.1),
     });
 
     minSelectedPrice ??= sliderRange.min;

--- a/src/wix/utils/align-range.ts
+++ b/src/wix/utils/align-range.ts
@@ -1,0 +1,65 @@
+export interface RangeWithStep {
+    min: number;
+    max: number;
+    step: number;
+}
+
+/**
+ * Rounds step size to a nice number like 0.5, 1, 2, 5, 10, and aligns range
+ * bounds to this step. May expand the range, but never shrinks it.
+ * @example
+ * Input:  { min: 6.3, max: 28.1, step: 3.8 }
+ * Output: { min: 5,   max: 30,   step: 5   }
+ */
+export const alignRangeToNiceStep = ({ min, max, step }: RangeWithStep): RangeWithStep => {
+    if (step <= 0) throw new RangeError(`Invalid step size: ${step}`);
+    if (min > max) throw new RangeError(`Invalid range: ${min}, ${max}`);
+
+    const { mantissa, exponent } = roundStepToNiceNumber(step);
+
+    step = mantissa * 10 ** exponent;
+    min = roundDownToStep(min, step);
+    max = roundUpToStep(max, step);
+
+    // Adjust for precision errors in binary representation of decimal fractions.
+    // During step calculation: 10 ** -4 = 0.00009999999999999999
+    // During bound rounding: 12 * 0.1 = 1.2000000000000002
+    if (exponent < 0) {
+        step = roundDecimal(step, -exponent);
+        min = roundDecimal(min, -exponent);
+        max = roundDecimal(max, -exponent);
+    }
+
+    return { min, max, step };
+};
+
+/**
+ * Rounds a step size to a nice number based on divisors of ten (1, 2, 5):
+ * - 1×10ⁿ: ..., 0.1, 1, 10, ...
+ * - 2×10ⁿ: ..., 0.2, 2, 20, ...
+ * - 5×10ⁿ: ..., 0.5, 5, 50, ...
+ */
+const roundStepToNiceNumber = (step: number) => {
+    const exponent = Math.floor(Math.log10(step));
+    const mantissa = step / 10 ** exponent;
+    if (mantissa < 1.5) return { mantissa: 1, exponent };
+    if (mantissa < 3.5) return { mantissa: 2, exponent };
+    if (mantissa < 7.5) return { mantissa: 5, exponent };
+    return { mantissa: 1, exponent: exponent + 1 };
+};
+
+/** Rounds a number down to the nearest multiple of `step`. */
+const roundDownToStep = (x: number, step: number): number => {
+    return Math.floor(x / step) * step;
+};
+
+/** Rounds a number up to the nearest multiple of `step`. */
+const roundUpToStep = (x: number, step: number): number => {
+    return Math.ceil(x / step) * step;
+};
+
+/** Rounds a number to a specified number of decimal places. */
+const roundDecimal = (x: number, decimalPlaces: number): number => {
+    const scale = 10 ** decimalPlaces;
+    return Math.round(x * scale) / scale;
+};


### PR DESCRIPTION
When the price range is large, it's difficult to adjust the slider via keyboard because `step = 1`:

https://github.com/user-attachments/assets/651493d3-3d63-4845-9d94-230b28746bbf

A quick fix could look like this:
```ts
const step = maxAvailablePrice > 500 ? 10 : 1;
```

But this wouldn't solve the issue for prices above 10 000, and would break alignment of range bounds with the step size.

We should have probably ignored this entire "problem", but I couldn't let practicality stand in the way of solving a nice math puzzle. So I've created a function `alignRangeToNiceStep` that makes things nice:

https://github.com/user-attachments/assets/71d97c71-1eeb-424a-a99d-602d21f720f0

The implementation could have been condensed into 10-15 lines, but I went for readability.
