### PR TITLE
refactor: json -> data (for future compat)

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -4,7 +4,7 @@ import '~/src/styles/typography.scss';
 import '~/src/styles/global.scss';
 import '~/src/styles/utils.scss';
 
-import { json, LoaderFunctionArgs } from '@remix-run/node';
+import { data, type LoaderFunctionArgs } from '@remix-run/node';
 import {
     Links,
     Meta,
@@ -30,7 +30,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const { wixSessionTokens, session, shouldUpdateSessionCookie } =
         await initializeEcomSession(request);
 
-    const data = {
+    const payload = {
         wixClientId: getWixClientId(),
         wixSessionTokens,
     };
@@ -39,7 +39,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         ? { 'Set-Cookie': await commitSession(session) }
         : {};
 
-    return json(data, { headers });
+    return data(payload, { headers });
 }
 
 const breadcrumbs: RouteBreadcrumbs = () => [{ title: 'Home', to: '/' }];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { netlifyPlugin } from '@netlify/remix-adapter/plugin';
 
+declare module '@remix-run/node' {
+    interface Future {
+        v3_singleFetch: true;
+    }
+}
+
 export default defineConfig({
     plugins: [
         remix({


### PR DESCRIPTION
drops the last usage of deprecated `json` and replaces it with a call to `data` (needed for the `headers` option)

we need to ensure Codux supports the `data` hook before merging this.