### PR TITLE
feat: renew wix auth token

### DIFF
--- a/src/wix/ecom/session.ts
+++ b/src/wix/ecom/session.ts
@@ -66,6 +66,9 @@ export async function initializeEcomApiForRequest(request: Request) {
         : initializeEcomApiAnonymous();
 }
 
+// renew token in one hour before expiration. the token lifetime is 4 hours
+const TOKEN_REFRESH_MARGIN_SECONDS = 60 * 60;
+
 async function getValidAuthTokens(sessionTokens: Tokens | undefined) {
     const client = createWixClient(sessionTokens);
 
@@ -77,7 +80,10 @@ async function getValidAuthTokens(sessionTokens: Tokens | undefined) {
         effectiveTokens = sessionTokens;
 
         const currentTimeStampSeconds = Date.now() / 1000;
-        if (currentTimeStampSeconds > effectiveTokens.accessToken.expiresAt) {
+        if (
+            currentTimeStampSeconds >
+            effectiveTokens.accessToken.expiresAt - TOKEN_REFRESH_MARGIN_SECONDS
+        ) {
             try {
                 effectiveTokens = await client.auth.renewToken(sessionTokens.refreshToken);
             } catch {

--- a/src/wix/ecom/session.ts
+++ b/src/wix/ecom/session.ts
@@ -87,7 +87,6 @@ async function getValidAuthTokens(sessionTokens: Tokens | undefined) {
             try {
                 effectiveTokens = await client.auth.renewToken(sessionTokens.refreshToken);
             } catch {
-                // generate new visitor tokens if renewing process failed
                 effectiveTokens = await client.auth.generateVisitorTokens();
             }
         }

--- a/src/wix/ecom/session.ts
+++ b/src/wix/ecom/session.ts
@@ -43,12 +43,12 @@ export async function initializeEcomSession(request: Request) {
     const wixSessionTokens =
         sessionWixClientId === wixClientId ? session.get('wixSessionTokens') : undefined;
 
-    const effectiveTokens = await getEffectiveWixAuthTokens(wixSessionTokens);
+    const validTokens = await getValidAuthTokens(wixSessionTokens);
 
     let shouldUpdateSessionCookie = false;
-    if (effectiveTokens !== wixSessionTokens) {
+    if (validTokens !== wixSessionTokens) {
         shouldUpdateSessionCookie = true;
-        session.set('wixSessionTokens', effectiveTokens);
+        session.set('wixSessionTokens', validTokens);
     }
 
     if (sessionWixClientId !== wixClientId) {
@@ -56,7 +56,7 @@ export async function initializeEcomSession(request: Request) {
         session.set('wixClientId', wixClientId);
     }
 
-    return { wixSessionTokens: effectiveTokens, session, shouldUpdateSessionCookie };
+    return { wixSessionTokens: validTokens, session, shouldUpdateSessionCookie };
 }
 
 export async function initializeEcomApiForRequest(request: Request) {
@@ -66,7 +66,7 @@ export async function initializeEcomApiForRequest(request: Request) {
         : initializeEcomApiAnonymous();
 }
 
-async function getEffectiveWixAuthTokens(sessionTokens: Tokens | undefined) {
+async function getValidAuthTokens(sessionTokens: Tokens | undefined) {
     const client = createWixClient(sessionTokens);
 
     let effectiveTokens: Tokens | undefined;


### PR DESCRIPTION
**Summary:**
This PR renews the Wix authentication token and saves it in the session if it has expired. If the renewal process fails, it logs the user out by generating a new visitor auth token.

**Frontend Considerations:**
The frontend side token refresh is not addressed in this PR due to the following reasons:
- In order to token expire, a user would need to leave the page inactive for 4 hours (the access token’s lifetime), then resume interaction without a full page reload or opening a new tab.
- Addressing this would significantly increase template code complexity.
- Additionally, the Wix SDK automatically updates expired tokens before each request. While the updated token is not preserved, the SDK will continue to fetch a new token before every request if the token expires. This could be viewed as a potential SDK issue rather than a frontend flaw.
