### PR TITLE
fix: don't show delivery price if no shipping region is detected

### DIFF
--- a/app/routes/cart/route.tsx
+++ b/app/routes/cart/route.tsx
@@ -81,14 +81,16 @@ export default function CartPage() {
                         <span>Subtotal</span>
                         <span>{cartTotals?.priceSummary?.subtotal?.formattedConvertedAmount}</span>
                     </div>
-                    <div className={styles.summaryRow}>
-                        <span>Delivery</span>
-                        <span>
-                            {Number(cartTotals?.priceSummary?.shipping?.amount) === 0
-                                ? 'FREE'
-                                : cartTotals?.priceSummary?.shipping?.formattedConvertedAmount}
-                        </span>
-                    </div>
+                    {cartTotals?.shippingInfo?.region && (
+                        <div className={styles.summaryRow}>
+                            <span>Delivery</span>
+                            <span>
+                                {Number(cartTotals?.priceSummary?.shipping?.amount) === 0
+                                    ? 'FREE'
+                                    : cartTotals?.priceSummary?.shipping?.formattedConvertedAmount}
+                            </span>
+                        </div>
+                    )}
                     <div className={classNames(styles.summaryRow, styles.summaryTotal)}>
                         <span>Total</span>
                         <span>{cartTotals?.priceSummary?.total?.formattedConvertedAmount}</span>


### PR DESCRIPTION
I there is only one shipping region (for. e.g. Poland) and user is located in another place (for e.g. Ukraine) then delivery price will be shown FREE, but actually it's not possible to deliver to Ukraine.
I hide delivery information if shipping region is undefined.