### PR TITLE
feat: add CSS vars for page background and text color

### DIFF
--- a/src/components/avatar/avatar.module.scss
+++ b/src/components/avatar/avatar.module.scss
@@ -1,7 +1,6 @@
 .root {
     width: 22px;
     height: 22px;
-    color: var(--primary5);
 }
 
 .root :is(img, svg) {

--- a/src/components/cart/cart-item/cart-item.module.scss
+++ b/src/components/cart/cart-item/cart-item.module.scss
@@ -115,7 +115,7 @@
 }
 
 .unavailableIcon {
-    color: var(--error);
+    color: var(--error-color);
     width: 20px;
     height: 20px;
 }

--- a/src/components/product-option/product-option.module.scss
+++ b/src/components/product-option/product-option.module.scss
@@ -8,6 +8,6 @@
     display: flex;
     align-items: center;
     gap: 4px;
-    color: var(--error);
+    color: var(--error-color);
     font: var(--paragraph3);
 }

--- a/src/components/select/select.module.scss
+++ b/src/components/select/select.module.scss
@@ -17,7 +17,7 @@
 }
 
 .trigger.hasError {
-    border-color: var(--error);
+    border-color: var(--error-color);
 }
 
 .trigger:hover,

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,4 +1,10 @@
 :root {
+    --page-background-color: #fef9ec;
+    --text-color: #17110d;
+    --error-color: #df3131;
+    /** Focus ring that appears when an element is focused via keyboard. */
+    --focus-ring-color: #414434;
+
     --primary1: #fef9ec;
     --primary2: #ffefc7;
     --primary3: #dad3c1;
@@ -10,9 +16,4 @@
     --secondary3: #707365;
     --secondary4: #414434;
     --secondary5: #22241b;
-
-    --error: #df3131;
-
-    /** Focus ring that appears when an element is focused via keyboard. */
-    --focus-ring-color: var(--secondary4);
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -4,14 +4,14 @@
 
 :root {
     font: var(--paragraph1);
-    color: var(--primary5);
+    color: var(--text-color);
     --pagePaddingHoriz: max(2vw, 15px);
 }
 
 body {
     min-width: 320px;
     min-height: 100vh;
-    background: var(--primary1);
+    background: var(--page-background-color);
 }
 
 :focus-visible {

--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -480,5 +480,5 @@
     --border-color: var(--primary3);
     --border-color-hover: var(--primary5);
     --border-color-selected: var(--primary4);
-    --border-color-error: var(--error);
+    --border-color-error: var(--error-color);
 }


### PR DESCRIPTION
Allow users to easily customize the `<body>` background and text colors through the global variables panel, as the style panel currently does not support editing the `<body>`.

<img width="241" alt="image" src="https://github.com/user-attachments/assets/f0ff87f8-0153-4ee6-8260-9962b989d121">
