### PR TITLE
fix: add @format comment before image url fields to allow using Wix Media Manager

### DIFF
--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -5,6 +5,7 @@ import styles from './avatar.module.scss';
 
 export interface AvatarProps {
     className?: string;
+    /** @format media-url */
     imageSrc: string | undefined;
 }
 

--- a/src/components/product-card/product-card.tsx
+++ b/src/components/product-card/product-card.tsx
@@ -5,6 +5,7 @@ import { ImagePlaceholderIcon } from '../icons';
 
 interface ProductCardProps {
     name: string;
+    /** @format media-url */
     imageUrl?: string;
     /**
      * Product price formatted with the currency.

--- a/src/components/visual-effects/background-parallax.tsx
+++ b/src/components/visual-effects/background-parallax.tsx
@@ -11,6 +11,7 @@ export interface BackgroundParallaxProps extends HTMLAttributes<HTMLDivElement> 
      *   the viewport, similar to `background-attachment: fixed`.
      */
     parallaxStrength?: number;
+    /** @format media-url */
     backgroundImageUrl?: string;
 }
 


### PR DESCRIPTION
Fixes #24075