### PR TITLE
fix: header styles on mobile

### DIFF
--- a/src/components/header/header.module.scss
+++ b/src/components/header/header.module.scss
@@ -18,9 +18,9 @@
 }
 
 .searchInput {
-    position: relative;
-    left: 1em;
-    width: 16em;
+    margin-left: 8px;
+    min-width: 4em;
+    max-width: 14em;
 }
 
 .advertisingText {
@@ -40,7 +40,7 @@
     font: var(--paragraph3);
 }
 
-.navigation .actions {
+.actions {
     display: flex;
     align-items: center;
     justify-content: flex-end;
@@ -48,11 +48,16 @@
     height: 50px;
     padding: 0 8px;
     gap: 30px;
+
+    & > * {
+        flex: none;
+    }
 }
 
 .cartButton {
     padding: 0;
 }
+
 .cart {
     transform: translateY(-2px);
 }
@@ -85,7 +90,7 @@
     }
 
     .navigation {
-        grid-template-columns: auto 1fr;
+        grid-template-columns: auto auto;
         align-items: center;
     }
 
@@ -100,9 +105,5 @@
         align-items: start;
         justify-content: center;
         font-size: 13px;
-    }
-
-    .searchInput {
-        width: 10em;
     }
 }

--- a/src/components/search-input/search-input.module.scss
+++ b/src/components/search-input/search-input.module.scss
@@ -1,15 +1,16 @@
-.form {
+.label {
     display: flex;
     align-items: center;
-    gap: 0.3em;
-    width: 100%;
+    gap: 8px;
+    font: var(--paragraph3);
 }
 
 .input {
     flex: 1;
     border: none;
+    padding: 0;
     background: none;
-    font-size: 0.9em;
+    min-width: 0;
 
     &:focus-visible {
         box-shadow: none;
@@ -17,14 +18,14 @@
 }
 
 .searchIcon {
-    width: 1em;
-    height: 1em;
+    width: 14px;
+    height: 14px;
 }
 
 .clearIcon {
     cursor: pointer;
-    width: 0.6em;
-    height: 0.6em;
+    width: 8px;
+    height: 8px;
 }
 
 .input:placeholder-shown + .clearIcon {

--- a/src/components/search-input/search-input.tsx
+++ b/src/components/search-input/search-input.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@remix-run/react';
-import React, { useCallback, useId } from 'react';
+import { type FC, type FormEventHandler, useState } from 'react';
 import { CrossSmallIcon, SearchIcon } from '../icons';
 import styles from './search-input.module.scss';
 
@@ -9,42 +9,33 @@ export interface SearchInputProps {
     onSearchSubmit?: (value: string) => void;
 }
 
-export const SearchInput = React.memo<SearchInputProps>(function SearchInput({
+export const SearchInput: FC<SearchInputProps> = ({
     className,
-    defaultValue,
+    defaultValue = '',
     onSearchSubmit,
-}) {
-    const inputRef = React.useRef<HTMLInputElement>(null);
-    // input is uncontrolled, so we clear it manually
-    const onClickClear = useCallback(() => (inputRef.current!.value = ''), []);
+}) => {
+    const [value, setValue] = useState(defaultValue);
 
-    const onSubmit: React.EventHandler<React.FormEvent<HTMLFormElement>> = (event) => {
+    const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        const search = formData.get('search');
-        if (typeof search === 'string' && search.trim() !== '') {
-            onSearchSubmit?.(search);
-        }
+        if (value.trim()) onSearchSubmit?.(value);
     };
-    const inputId = useId();
 
     return (
-        <label className={className} htmlFor={inputId}>
-            <Form className={styles.form} role="search" onSubmit={onSubmit}>
-                <SearchIcon className={styles.searchIcon} width={14} />
+        <Form className={className} role="search" onSubmit={handleSubmit}>
+            <label className={styles.label}>
+                <SearchIcon className={styles.searchIcon} />
                 <input
-                    id={inputId}
-                    ref={inputRef}
                     className={styles.input}
                     type="text"
-                    name="search"
                     spellCheck="false"
-                    defaultValue={defaultValue}
                     placeholder="Search"
                     minLength={2}
+                    value={value}
+                    onChange={(event) => setValue(event.target.value)}
                 />
-                <CrossSmallIcon className={styles.clearIcon} onClick={onClickClear} />
-            </Form>
-        </label>
+                <CrossSmallIcon className={styles.clearIcon} onClick={() => setValue('')} />
+            </label>
+        </Form>
     );
-});
+};

--- a/src/components/user-menu/user-menu.module.scss
+++ b/src/components/user-menu/user-menu.module.scss
@@ -1,11 +1,12 @@
-.root,
-.root.link {
-    cursor: pointer;
-    background-color: transparent;
-    border: none;
+.root {
+    padding: 0;
+    border: 0;
     display: flex;
     align-items: center;
     gap: 12px;
+    font: var(--paragraph3);
+    cursor: pointer;
+    background-color: transparent;
 }
 
 .link {

--- a/src/components/user-menu/user-menu.tsx
+++ b/src/components/user-menu/user-menu.tsx
@@ -1,5 +1,4 @@
 import { NavLink } from '@remix-run/react';
-import classNames from 'classnames';
 import { Avatar } from '~/src/components/avatar/avatar';
 import {
     DropdownMenu,
@@ -16,7 +15,7 @@ export const UserMenu = () => {
 
     if (!isLoggedIn) {
         return (
-            <NavLink className={classNames(styles.link, styles.root)} to={'/login'}>
+            <NavLink className={styles.root} to={'/login'}>
                 <Avatar imageSrc={undefined} />
                 Log In
             </NavLink>


### PR DESCRIPTION
On mobile, the icons in the search input were disappearing, "Log in" was wrapping to the next line, the user icon and the hamburger icons were shrinking.

### Before

<img width="375" alt="header-before" src="https://github.com/user-attachments/assets/48e5cc4e-28e6-443f-b684-cc4ca81c315c">

### After

<img width="375" alt="header-after" src="https://github.com/user-attachments/assets/2693c58c-4eca-4b2c-8c46-e591719ef2b5">

---

Tweaks to the search input:

* Moved the `<label>` inside the `<Form>`.
* Removed `memo` since the props weren't memoized anyway, and the component isn't on the hot path. Maybe we should memoize the `<Header>` component.
* Simplified code for `clear` and `submit`.
* Fixed the font size (it was off by one pixel).
* Tried to stick with `em` units, but getting the sizes right, rather than just approximately right, turned out to be too much of a hassle. You have to keep track of the current font size and end up with awkward values like `0.571em`. Ain't nobody got time for that.
* Removed browser's default `min-width` and `padding` from the input. The old `reset.css` was taking care of this. With the new "improved" `reset.css` we have to repeat the same garbage over and over.


