### PR TITLE
fix: workaround for Codux showing 4 instances of the App component in the element tree

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,16 +74,18 @@ export default function App() {
     return (
         <EcomApiContextProvider tokens={wixSessionTokens}>
             <CartOpenContextProvider>
-                <div className={styles.root}>
-                    <Header />
-                    <main className={styles.main}>
-                        <Outlet />
-                    </main>
-                    <Footer />
+                <div>
+                    <div className={styles.root}>
+                        <Header />
+                        <main className={styles.main}>
+                            <Outlet />
+                        </main>
+                        <Footer />
+                    </div>
+                    <Cart />
+                    <NavigationProgressBar className={styles.navigationProgressBar} />
+                    <Toaster />
                 </div>
-                <Cart />
-                <NavigationProgressBar className={styles.navigationProgressBar} />
-                <Toaster />
             </CartOpenContextProvider>
         </EcomApiContextProvider>
     );


### PR DESCRIPTION
Due to a bug in Codux, the App component appears four times in the element tree. This happens when the component doesn't have a single root DOM element.

https://github.com/wixplosives/codux/issues/24380
https://github.com/wixplosives/codux/issues/21951

![image](https://github.com/user-attachments/assets/e6891c44-aa26-48c1-85c1-22340d9aba4f)
