### PR TITLE
fix: reset selected options and quantity when navigating between products

### DIFF
--- a/app/routes/product-details.$productSlug/route.tsx
+++ b/app/routes/product-details.$productSlug/route.tsx
@@ -69,6 +69,13 @@ export const handle = {
 };
 
 export default function ProductDetailsPage() {
+    const { product } = useLoaderData<typeof loader>();
+    // The `key` ensures the component state, such as selected options or
+    // quantity, resets when navigating between products.
+    return <ProductDetails key={product._id} />;
+}
+
+function ProductDetails() {
     const { product, canonicalUrl } = useLoaderData<typeof loader>();
 
     const {


### PR DESCRIPTION
During client-side navigation between product pages, we need to ensure that React state (such as selected product options, quantity, selected photo) is not retained.