### PR TITLE
fix: do not load car totals if there is no cart

### DIFF
--- a/src/wix/cart/use-cart.tsx
+++ b/src/wix/cart/use-cart.tsx
@@ -10,7 +10,11 @@ const useCartTotals = () => {
     const ecomApi = useEcomApi();
     const cart = useCartData();
     useEffect(() => void mutate('cart-totals'), [cart.data]);
-    return useSwr('cart-totals', () => ecomApi.getCartTotals());
+    return useSwr('cart-totals', () => {
+        if (cart.data) {
+            return ecomApi.getCartTotals();
+        }
+    });
 };
 
 interface AddToCartArgs {


### PR DESCRIPTION
- skip loading cart totals if there is no cart

NOTE: this is still not a full fix, I'm continue investigating and working on needless requests and console errors